### PR TITLE
Prevent first item from being automatically selected in context menu

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -24,8 +24,8 @@
     -GtkExpander-expander-size: 12;
     -GtkHTML-link-color: @link_color;
     -GtkIMHtml-hyperlink-color: @link_color;
-    -GtkMenu-horizontal-padding: 0;
-    -GtkMenu-vertical-padding: 0;  
+    -GtkMenu-horizontal-padding: 1;
+    -GtkMenu-vertical-padding: 1;
     -GtkMenuBar-internal-padding: 0;
     -GtkMenuItem-arrow-scaling: 0.4;
     -GtkNotebook-initial-gap: 0;


### PR DESCRIPTION
after a right-click.
