### PR TITLE
Restored 2px border to GTK-3 version of Mint-X menus

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -24,8 +24,8 @@
     -GtkExpander-expander-size: 12;
     -GtkHTML-link-color: @link_color;
     -GtkIMHtml-hyperlink-color: @link_color;
-    -GtkMenu-horizontal-padding: 0;
-    -GtkMenu-vertical-padding: 0;  
+    -GtkMenu-horizontal-padding: 2;
+    -GtkMenu-vertical-padding: 2;  
     -GtkMenuBar-internal-padding: 0;
     -GtkMenuItem-arrow-scaling: 0.4;
     -GtkNotebook-initial-gap: 0;


### PR DESCRIPTION
To be consistent with GTK-2 theming and reinstate the fix for misclick menu activation. This is the simple restoration of theming consistency outlined in issue #9.
