### PR TITLE
Darkened GtkTreeView and Menu theme to improve readability.

### DIFF
--- a/usr/share/themes/Mint-X/gtk-2.0/Styles/list.rc
+++ b/usr/share/themes/Mint-X/gtk-2.0/Styles/list.rc
@@ -1,7 +1,7 @@
 style "treeview" = "default"
 {
-	base[SELECTED]					= shade (1.1, @selected_bg_color)
-	base[ACTIVE]					= shade (1.1, @selected_bg_color)
+	base[SELECTED]					= shade (0.8, @selected_bg_color)
+	base[ACTIVE]					= shade (0.8, @selected_bg_color)
 
 	xthickness					= 1
 	ythickness					= 1

--- a/usr/share/themes/Mint-X/gtk-2.0/Styles/menu.rc
+++ b/usr/share/themes/Mint-X/gtk-2.0/Styles/menu.rc
@@ -3,9 +3,9 @@ style "menu"
 	xthickness 					= 0
 	ythickness 					= 0
 
-	bg[SELECTED] 					= shade (0.99, @selected_bg_color)
+	bg[SELECTED] 					= shade (0.8, @selected_bg_color)
 	bg[NORMAL] 					= @menu_bg_color
-	bg[PRELIGHT] 					= shade (0.99, @selected_bg_color)
+	bg[PRELIGHT] 					= shade (0.8, @selected_bg_color)
 	bg[ACTIVE] 					= @menu_bg_color
 	bg[INSENSITIVE] 				= @menu_bg_color
 	fg[NORMAL] 					= @menu_fg_color
@@ -32,8 +32,8 @@ style "menu-item" 					= "wider"
 	xthickness 					= 2
 	ythickness 					= 2
 
-	bg[SELECTED] 					=  shade (0.99, @selected_bg_color)
-	bg[PRELIGHT] 					= shade (0.99, @selected_bg_color)
+	bg[SELECTED] 					=  shade (0.8, @selected_bg_color)
+	bg[PRELIGHT] 					= shade (0.8, @selected_bg_color)
 	fg[NORMAL] 					= @menu_fg_color
 	fg[PRELIGHT] 					= @selected_fg_color
 	fg[SELECTED] 					= @selected_fg_color

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -405,12 +405,13 @@ GtkSwitch.slider,
 row:selected,
 row:selected:focus {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_selected_bg_color, 1.2)),
-                                     to (shade(@theme_selected_bg_color, 1.0)));
+                                    color-stop(0, shade(@theme_selected_bg_color, 0.9)),
+                                    color-stop(0.3, shade(@theme_selected_bg_color, 0.8)),
+                                    color-stop(0.7, shade(@theme_selected_bg_color, 0.8)),
+                                    color-stop(1, shade(@theme_selected_bg_color, 0.75)));
 
     border-color: shade(@theme_selected_bg_color, 0.8);
     border-style: solid;
-    border-width: 1px 0;
     color: @theme_selected_fg_color;
 }
 
@@ -882,10 +883,12 @@ GtkComboBox .menu {
 .menubar.menuitem:hover,
 .menubar .menuitem:hover {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_selected_bg_color, 1.2)),
-                                     to (shade(@theme_selected_bg_color, 1.0)));
+                                    color-stop(0, shade(@theme_selected_bg_color, 0.9)),
+                                    color-stop(0.3, shade(@theme_selected_bg_color, 0.8)),
+                                    color-stop(0.7, shade(@theme_selected_bg_color, 0.8)),
+                                    color-stop(1, shade(@theme_selected_bg_color, 0.75)));
 
-    border-color: shade(@theme_selected_bg_color, 1.1);
+    border-color: shade(@theme_selected_bg_color, 0.7);
 }
 
 .menubar .menuitem *:hover {
@@ -915,11 +918,13 @@ GtkTreeMenu .menuitem * {
 .menu .menuitem:active,
 .menu .menuitem:hover {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_selected_bg_color, 1.2)),
-                                     to (shade(@theme_selected_bg_color, 1.0)));
+                                    color-stop(0, shade(@theme_selected_bg_color, 0.9)),
+                                    color-stop(0.3, shade(@theme_selected_bg_color, 0.8)),
+                                    color-stop(0.7, shade(@theme_selected_bg_color, 0.8)),
+                                    color-stop(1, shade(@theme_selected_bg_color, 0.75)));
 
     border-radius: 0;
-    border-color: shade(@theme_selected_bg_color, 0.8);
+    border-color: shade(@theme_selected_bg_color, 0.7);
 }
 
 .menu .menuitem:active,


### PR DESCRIPTION
These changes darken the TreeView and Menu background gradients to
improve their readability. Roughly proportional changes have also been
applied to the same objects in the GTK2 theme for consistency.

The effect is to produce a darker theme which displays which displays
white text much more clearly.

![Sample Screenshort](http://i.imgur.com/AvC1C.png)
