### PR TITLE
Nemo sidebar text drop-shadow removal

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/apps/nemo.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/apps/nemo.css
@@ -6,6 +6,9 @@ NemoWindow .sidebar .view {
 	/* text-shadow: 1px 1px alpha (#000000, 0.8); */
 }
 
+NemoWindow .sidebar .view:selected {
+	color: #EEEEEE;
+}
 
 /* inactive pane */
 


### PR DESCRIPTION
Removed the drop shadow from the Nemo sidebar text, which improves the overall look considerably.

![](http://i.imgur.com/75gcfUb.png)
