### PR TITLE
Add a hover pre-light effect to GtkTreeView and Nemo sidepane.

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/apps/nemo.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/apps/nemo.css
@@ -7,6 +7,10 @@ NemoWindow .sidebar .view {
 }
 
 
+NemoWindow .sidebar .view:hover {
+    background-color: shade(#3F3F3F , 1.4);
+}
+
 /* inactive pane */
 
 .nemo-inactive-pane .view {

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1830,6 +1830,10 @@ GtkTreeView row:nth-child(odd) {
     background-color: #FFFFFF;
 }
 
+GtkTreeView row:hover {
+    background-color: shade(@theme_selected_bg_color, 1.2);
+}
+
 /************
  * viewport *
  ************/


### PR DESCRIPTION
GtkTreeViews tended to feel unfriendly and static in Mint-X. This was
most noticeable in Nemo.

This modification adds a simple highlight to all GTK3 GtkTreeViews,
making them feel much more lively and responsive.

A separate sidepane modification is included for Nemo specifically.

Nemo:
![](http://i.imgur.com/Cxa3uBN.png)

Nemo Sidepane:
![](http://i.imgur.com/mumELkJ.png)
