### PR TITLE
Nemo inactive pane improvement

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/apps/nemo.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/apps/nemo.css
@@ -11,3 +11,7 @@ NemoWindow .sidebar .view {
 .nemo-inactive-pane .view {
     background-color: shade(@theme_base_color, 0.95);
 }
+
+.nemo-inactive-pane .view:selected {
+    background-color: @theme_selected_bg_color;
+}


### PR DESCRIPTION
Fixes the problem of icons in the inactive pane not correctly displayed background-selection colors:

OLD:
![](http://i.imgur.com/nT44KV0.png)

NEW:
![](http://i.imgur.com/Fo8xba5.png)

Proviso: this working depends on the application-priority background-color setting that is included in Nemo itself being unset, otherwise Nemo will override the theme setting. Worst case it will do nothing without the right build.
