### PR TITLE
Fix GTK3 menubar items not having a border.

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -876,7 +876,7 @@ GtkComboBox .menu {
  ***************/
 .menubar.menuitem,
 .menubar .menuitem {
-    border-width: 0;
+    border-width: 1px;
     padding: 3px 5px 3px 5px;
 }
 


### PR DESCRIPTION
GTK3 menubar items were accidentally set to border-width: 0 instead of
1px. This fixes them and improves the overall look.

OLD:
![](http://i.imgur.com/d3O8Lz1.png)

NEW:
![](http://i.imgur.com/gyHmeiT.png)

It's subtle, but important and greatly improves the overall look - it can be altered quite dramatically by other shadings as well.
