### PR TITLE
Add .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Eclipse stuff
+.project


### PR DESCRIPTION
Adds Eclipse project files to ignore (useful for Git merging).

Could have other project/management files added to it in the future, so we probably should have one (or for a hypothetical case where we have a build path which renders out SVG files).
