### PR TITLE
Normalize GTK2/3 menu-coloring.

### DIFF
--- a/usr/share/themes/Mint-X/gtk-2.0/Styles/menu.rc
+++ b/usr/share/themes/Mint-X/gtk-2.0/Styles/menu.rc
@@ -3,17 +3,17 @@ style "menu"
 	xthickness 					= 0
 	ythickness 					= 0
 
-	bg[SELECTED] 					= shade (0.8, @selected_bg_color)
-	bg[NORMAL] 					= @menu_bg_color
-	bg[PRELIGHT] 					= shade (0.8, @selected_bg_color)
-	bg[ACTIVE] 					= @menu_bg_color
+	bg[SELECTED] 					= @selected_bg_color
+	bg[NORMAL] 					    = @menu_bg_color
+	bg[PRELIGHT] 					= @selected_bg_color
+	bg[ACTIVE] 					    = @menu_bg_color
 	bg[INSENSITIVE] 				= @menu_bg_color
-	fg[NORMAL] 					= @menu_fg_color
+	fg[NORMAL] 					    = @menu_fg_color
 	fg[PRELIGHT] 					= @selected_fg_color
 	fg[SELECTED] 					= @selected_fg_color
-	fg[ACTIVE] 					= @selected_fg_color
+	fg[ACTIVE] 					    = @selected_fg_color
 	fg[INSENSITIVE] 				= shade (5.0, @menu_fg_color)
-	text[NORMAL] 					= shade (1.1, @fg_color)
+	text[NORMAL] 					= @fg_color
 	base[NORMAL] 					= @base_color
 	text[PRELIGHT] 					= @selected_fg_color
 	text[SELECTED] 					= @selected_fg_color
@@ -32,9 +32,9 @@ style "menu-item" 					= "wider"
 	xthickness 					= 2
 	ythickness 					= 2
 
-	bg[SELECTED] 					=  shade (0.8, @selected_bg_color)
-	bg[PRELIGHT] 					= shade (0.8, @selected_bg_color)
-	fg[NORMAL] 					= @menu_fg_color
+	bg[SELECTED] 					= @selected_bg_color
+	bg[PRELIGHT] 					= @selected_bg_color
+	fg[NORMAL] 					    = @menu_fg_color
 	fg[PRELIGHT] 					= @selected_fg_color
 	fg[SELECTED] 					= @selected_fg_color
 	text[PRELIGHT] 					= @selected_fg_color
@@ -63,14 +63,14 @@ style "menubar"
 	ythickness 					= 2
 
 	bg[SELECTED] 					= @bg_color
-	bg[NORMAL] 					= @bg_color
+	bg[NORMAL] 					    = @bg_color
 	bg[PRELIGHT] 					= @selected_bg_color
-	bg[ACTIVE] 					= shade (1.05, @menu_bg_color)
+	bg[ACTIVE] 					    = shade (1.05, @menu_bg_color)
 	bg[INSENSITIVE] 				= @bg_color
-	fg[NORMAL] 					= @menu_fg_color
+	fg[NORMAL] 					    = @menu_fg_color
 	fg[PRELIGHT] 					= @selected_fg_color
 	fg[SELECTED] 					= @selected_fg_color
-	fg[ACTIVE] 					= @selected_fg_color
+	fg[ACTIVE] 					    = @selected_fg_color
 	fg[INSENSITIVE] 				= shade (0.75, @menu_fg_color)
 	text[NORMAL] 					= @menu_fg_color
 	text[PRELIGHT] 					= @selected_fg_color


### PR DESCRIPTION
Menu-colors are now set directly by the selected
backgrond color, rather then arbitrarily being a few shades darker.

Removes the shade effects from GTK2 menu select coloring to
bring them inline with the average effect achieved by the gradients in
GTK3 (which is very subtle now).

This brings GTK2/3 menus in-line with each other, favoring the lighter
candy-green look and maintaining consistency with the select color of
other UI elements.

OLD:
![](http://i.imgur.com/l1NwYtj.png)

NEW:
![](http://i.imgur.com/Z9FxdaH.png)
