### PR TITLE
GTK2-style buttons for GTK3

### DIFF
--- a/usr/share/themes/Mint-X/gtk-2.0/Styles/buttons.rc
+++ b/usr/share/themes/Mint-X/gtk-2.0/Styles/buttons.rc
@@ -11,12 +11,12 @@ style "button" 						= "wider"
 	engine "murrine" 
 	{
 		contrast 	    			= 1.0
-		highlight_shade	    			= 1.02
+		highlight_shade	    			= 1.0
 		lightborder_shade   			= 1.7
-		gradient_shades     			= {1.3,1.25,1.01,0.92} 
-		border_shades 	    			= {1.03,0.8}
+		gradient_shades     			= {1.3,1.3,0.92,0.92} 
+		border_shades 	    			= {0.8,0.8}
 		shadow_shades	    			= {0.5,0.0}
-		reliefstyle 	    			= 3
+		reliefstyle 	    			= 0
 	}
 }
 

--- a/usr/share/themes/Mint-X/gtk-2.0/gtkrc
+++ b/usr/share/themes/Mint-X/gtk-2.0/gtkrc
@@ -87,7 +87,7 @@ style "default"
 		glazestyle          			= 3 
 		gradient_shades     			= {1.1,1.07,1.01,0.98} 
 		progressbarstyle    			= 1
-		focus_color         			= shade (1.2, @selected_bg_color)
+		focus_color         			= @selected_bg_color
 		glowstyle	    			= 0
 		glow_shade          			= 1.3
 		highlight_shade     			= 1.07

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -99,7 +99,7 @@ GtkWindow {
 
 *:selected,
 *:selected:focus {
-    background-color: alpha(@theme_selected_bg_color, 0.9);
+    background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
 }
 
@@ -237,94 +237,82 @@ GtkAssistant .sidebar {
  * button *
  **********/
 .button {
-    -GtkWidget-focus-padding: 1;
+    -GtkWidget-focus-padding: 0;
     -GtkWidget-focus-line-width: 0;
 
-    padding: 2px;
+	padding: 4px 14px;
+}
+
+GtkComboBox .button {
+	padding: 2px 2px;
 }
 
 GtkSwitch.slider,
 .button {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 1.02), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 1.02), 0.97)));
+                                     from (shade(shade(@theme_bg_color, 1.13), 1.3)),
+                                     to (shade(shade(@theme_bg_color, 1.13), 0.92)));
 
     border-radius: 3px;
-    border-top-color: shade(@theme_bg_color, 0.8);
-    border-right-color: shade(@theme_bg_color, 0.72);
-    border-bottom-color: shade(@theme_bg_color, 0.7);
-    border-left-color: shade(@theme_bg_color, 0.72);
     border-style: solid;
+    border-color: shade(@theme_bg_color, 0.65);
     color: @theme_fg_color;
 }
 
 .button:active {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.85), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.85), 0.97)));
+                                     from (shade(shade(@theme_bg_color, 0.8), 1.3)),
+                                     to (shade(shade(@theme_bg_color, 0.8), 0.92)));
 
-    border-color: shade(@theme_bg_color, 0.6);
+    border-color: shade(@theme_bg_color, 0.65);
 }
 
 .button:hover,
 .button:active:hover {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.15)),
-                                     to (shade(@theme_bg_color, 1.07)));
-
-    border-top-color: shade(@theme_bg_color, 0.85);
-    border-right-color: shade(@theme_bg_color, 0.78);
-    border-bottom-color: shade(@theme_bg_color, 0.7);
-    border-left-color: shade(@theme_bg_color, 0.78);
+        from (shade(mix(@theme_focus_color, @theme_bg_color, 0.96), 1.3)),
+        to (shade(mix(@theme_focus_color, @theme_bg_color, 0.96), 0.92)));
 }
 
 .button:focus,
 .button:hover:focus,
-.button:active:focus {
-    border-color: shade(@theme_selected_bg_color, 0.8);
+.button:active:focus {   
+    background-image: -gtk-gradient(linear, left top, left bottom,
+        from (shade(mix(@theme_focus_color, @theme_bg_color, 0.7), 1.3)),
+        to (shade(mix(@theme_focus_color, @theme_bg_color, 0.7), 0.92)));
+    border-color: @theme_selected_bg_color;
 }
 
 .button:insensitive {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
+                                     from (shade(shade(@theme_bg_color, 1.055), 1.3)),
+                                     to (shade(shade(@theme_bg_color, 1.055), 0.92)));
 
     border-color: shade(@theme_bg_color, 0.8);
 }
 
 .button:insensitive:active {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
+                             from (shade(shade(@theme_bg_color, 0.95), 1.05)),
+                             to (shade(shade(@theme_bg_color, 0.95), 0.97)));
 }
 
 /* default button */
+
 .button.default {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(alpha(@theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(alpha(@theme_selected_bg_color, 0.7), 0.97)));
-
-    border-color: shade(@theme_selected_bg_color, 0.8);
+        from (shade(mix(@theme_focus_color, @theme_bg_color, 0.3), 1.3)),
+        to (shade(mix(@theme_focus_color, @theme_bg_color, 0.3), 0.92)));
 }
 
 .button.default:hover {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 0.97)));
+
 }
 
 .button.default:active {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(alpha(@theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(alpha(@theme_selected_bg_color, 0.7), 0.97)));
-
-    border-color: shade(@theme_selected_bg_color, 0.8);
 }
 
 .button.default:active:hover {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 0.97)));
 }
 
 /* middle button */
@@ -454,6 +442,8 @@ column-header .button {
 
     border-color: shade(@theme_bg_color, 0.97);
     border-bottom-color: shade(@theme_bg_color, 0.8);
+    
+    padding: 3px 2px;
 }
 
 column-header .button:hover {
@@ -1576,8 +1566,8 @@ GtkTextView {
 .primary-toolbar .button *,
 .primary-toolbar .button {
     background-color: transparent;
-    background-image: none;
-    border-color: transparent;
+    /*background-image: none;*/
+    /*border-color: transparent;*/
     border-radius: 3px;
     border-width: 1px;
     padding: 2px;
@@ -1589,47 +1579,22 @@ GtkTextView {
 .primary-toolbar .button:hover,
 .primary-toolbar .button:active,
 .primary-toolbar .button:insensitive {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.15)),
-                                     to (shade(@theme_bg_color, 1.07)));
-
-    border-color: shade(@theme_bg_color, 0.7);
 }
 
 .primary-toolbar .button:active {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.85), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.85), 0.97)));
-
-    border-color: shade(@theme_bg_color, 0.6);
 }
 
 .primary-toolbar .button:active:hover {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.15)),
-                                     to (shade(@theme_bg_color, 1.07)));
-
-    border-top-color: shade(@theme_bg_color, 0.85);
-    border-right-color: shade(@theme_bg_color, 0.78);
-    border-bottom-color: shade(@theme_bg_color, 0.7);
-    border-left-color: shade(@theme_bg_color, 0.78);
 }
 
 .primary-toolbar .button:active:insensitive,
 .primary-toolbar .button:insensitive {
-    border-color: shade(@theme_bg_color, 0.8);
 }
 
 .primary-toolbar .button:insensitive {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
 }
 
 .primary-toolbar .button:active:insensitive {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
 }
 
 .primary-toolbar .entry,

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk.css
@@ -7,6 +7,7 @@
 @define-color selected_fg_color #fff;
 @define-color tooltip_bg_color #000;
 @define-color tooltip_fg_color #e1e1e1;
+@define-color focus_color #94b06f;
 
 /* colormap actually used by the theme, to be overridden in other css files */
 @define-color theme_bg_color @bg_color;
@@ -17,6 +18,7 @@
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
 @define-color theme_tooltip_fg_color @tooltip_fg_color;
+@define-color theme_focus_color @focus_color;
 
 /* shadow effects */
 @define-color light_shadow #fff;

--- a/usr/share/themes/Mint-X/gtk-3.0/settings.ini
+++ b/usr/share/themes/Mint-X/gtk-3.0/settings.ini
@@ -1,4 +1,4 @@
 [Settings]
-gtk-color-scheme = "base_color:#ffffff\nbg_color:#d6d6d6\ntooltip_bg_color:#F5F5B5\nselected_bg_color:#accd8a\ntext_color:#2c2c2c\nfg_color:#2c2c2c\ntooltip_fg_color:#000000\nselected_fg_color:#F5F5F5\nlink_color:#42adc0\nbg_color_dark:#c9c9c9\nfg_color_dark:#2c2c2c"
+gtk-color-scheme = "base_color:#ffffff\nbg_color:#d6d6d6\ntooltip_bg_color:#F5F5B5\nselected_bg_color:#accd8a\ntext_color:#2c2c2c\nfg_color:#2c2c2c\ntooltip_fg_color:#000000\nselected_fg_color:#F5F5F5\nlink_color:#42adc0\nbg_color_dark:#c9c9c9\nfg_color_dark:#2c2c2c\nfocus_color:#94b06f"
 gtk-auto-mnemonics = 1
 gtk-visible-focus = automatic


### PR DESCRIPTION
Converts all button rendering to match the GTK2 murrine style in Mint-X as closely as possible.

GTK2:
![GTK2](http://i.imgur.com/gmSYgAA.png)

GTK3:
![GTK3](http://i.imgur.com/D1rXcMh.png)

A number of changes were required to achieve this across the full range of buttons in GTK (toolbars, comboboxes etc.) so I really recommend checking out the effect in A widget factory side-by-side.

This is a compromise to achieve consistency: I've dropped the outset shadow from GTK2, since it can't be replicated in GTK3 (inset shadows only). GTK3 looks less striking since the GTK2 murrine engine renders a non-linear curve that can't be easily recreated, but the effect is very similar and they will not often be seen side-by-side.

The selected effect has also been updated for GTK3 to be more noticeable - it's not possible to perfectly recreate the selection effect of murrine (that I can fathom - there's a lot of interacting and undocumented stuff in the new CSS spec):

Selected, GTK3 button:
![Selected GTK3](http://i.imgur.com/LNU75fz.png)
