### PR TITLE
GTK2/3 ProgressBar synchronization

### DIFF
--- a/usr/share/themes/Mint-X/gtk-2.0/Styles/sliders.rc
+++ b/usr/share/themes/Mint-X/gtk-2.0/Styles/sliders.rc
@@ -4,19 +4,20 @@ style "progressbar"
 	ythickness 					= 0
 
 	fg[PRELIGHT] 					= lighter (@selected_fg_color)
-  	bg[NORMAL]   					= shade (0.98, @bg_color)
+  	bg[NORMAL]   					= @bg_color
 	bg[SELECTED] 					= @selected_bg_color
 
 	engine "murrine" 
 	{
 		roundness 	    			= 2
-		gradient_shades     			= {0.95, 1.0, 1.1, 1.18}  
+		gradient_shades     			= {1.15, 1.15, 0.95, 0.95}  
 		lightborder_shade   			= 1.2
 		lightborderstyle    			= 1
 		glow_shade          			= 1.02
 		glowstyle 	    			= 0
 		highlight_shade     			= 1.02
-		trough_shades       			= { 0.87, 0.9}
+		trough_shades       			= { 0.95, 1.15 }
+		border_shades                     = {0.85,0.85}
 	}
 	
 }

--- a/usr/share/themes/Mint-X/gtk-2.0/gtkrc
+++ b/usr/share/themes/Mint-X/gtk-2.0/gtkrc
@@ -86,7 +86,7 @@ style "default"
 		contrast            			= 0.8
 		glazestyle          			= 3 
 		gradient_shades     			= {1.1,1.07,1.01,0.98} 
-		progressbarstyle    			= 1
+		progressbarstyle    			= 0
 		focus_color         			= shade (1.2, @selected_bg_color)
 		glowstyle	    			= 0
 		glow_shade          			= 1.3

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -31,8 +31,8 @@
     -GtkNotebook-initial-gap: 0;
     -GtkNotebook-tab-overlap: -2;
     -GtkPaned-handle-size: 3;
-    -GtkProgressBar-min-horizontal-bar-height: 10;
-    -GtkProgressBar-min-vertical-bar-width: 10;
+    -GtkProgressBar-min-horizontal-bar-height: 20;
+    -GtkProgressBar-min-vertical-bar-width: 20;
     -GtkRange-slider-width: 9;
     -GtkRange-stepper-size: 0;
     -GtkRange-stepper-spacing: 0;
@@ -1068,7 +1068,7 @@ GtkTreeMenu .menuitem * {
  *************************/
 GtkScale,
 GtkProgressBar {
-    border-radius: 4px;
+    border-radius: 3px;
     border-width: 1px;
     padding: 0;
 }


### PR DESCRIPTION
Since it's not possible to have the striping effect in GTK3's default
renderer, much less with animation, this patch instead reverts both to
have a matching block-style.

Post-patch:
GTK2:
![](http://i.imgur.com/sE2jxfM.png)

GTK3:
![](http://i.imgur.com/xb4VRBg.png)
