### PR TITLE
Nemo sidebar fix for treeview.

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -410,8 +410,8 @@ row:selected:focus {
                                     
     border-bottom: 1px;
     border-top: 1px;
-    border-bottom-color: @theme_base_color;
-    border-top-color: @theme_base_color;
+    border-bottom-color: transparent;
+    border-top-color: transparent;
     border-style: solid;
     
     box-shadow: inset 0px -1px shade(@theme_selected_bg_color, 0.913);


### PR DESCRIPTION
Simple fix for the Nemo sidebar gaining ugly rendering from the new
treeview. Instead of forcing the background color of the borders,
they're set transparent and pick up the correct color contextually.

Current:
![](http://i.imgur.com/TMZUz4G.png)

Proposed:
![](http://i.imgur.com/9GH2C0O.png)
