### PR TITLE
Chrome r-click menu unclickable items gray

### DIFF
--- a/usr/share/themes/Mint-X-Aqua/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Aqua/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Blue/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Blue/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Brown/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Brown/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Grey/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Grey/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Orange/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Orange/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Pink/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Pink/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Purple/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Purple/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Red/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Red/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Sand/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Sand/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X-Teal/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X-Teal/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {

--- a/usr/share/themes/Mint-X/gtk-2.0/styles/menus.rc
+++ b/usr/share/themes/Mint-X/gtk-2.0/styles/menus.rc
@@ -57,7 +57,7 @@ style "menu"
     text[PRELIGHT] = @base_color
     text[SELECTED] = @base_color
     text[ACTIVE] = @fg_color
-    text[INSENSITIVE] = @text_color
+    text[INSENSITIVE] = @bg_color
 
     engine "murrine" 
     {


### PR DESCRIPTION
This fixes issue #92 . I was using this patch for an hour (ran different apps (Qt, GTK+ etc.)), and didn't face any regressions