### PR TITLE
[Mint-X/Cinnamon] Cleanup and fixes

### DIFF
--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -434,24 +434,6 @@ StScrollBar StButton#vhandle:hover {
     spacing: 25px;
 }
 
-.workspace-controls {
-    visible-height: 35px; /* Amount visible before hovering */
-}
-
-.workspace-thumbnails-background {
-    border: 1px solid rgba(128, 128, 128, 0.4);
-    border-right: 0px;
-    border-radius: 0px 0px 0px 0px;
-    background-color: rgba(0, 0, 0, 0.5);
-    padding: 8px;
-}
-
-.workspace-thumbnails-background:rtl {
-    border-right: 1px;
-    border-left: 0px;
-    border-radius: 0px 0px 0px 0px;
-}
-
 .workspace-thumbnails {
     spacing: 26px;
     padding-left: 0.9em;
@@ -481,11 +463,6 @@ StScrollBar StButton#vhandle:hover {
 .workspace-close-button:hover {
     background-image: url("control-assets/close-hover.svg");
     transition-duration: 150;
-}
-
-.workspace-thumbnail-indicator {
-    outline: 2px solid white;
-    border: 1px solid #888;
 }
 
 .window-caption {
@@ -518,25 +495,6 @@ StScrollBar StButton#vhandle:hover {
     background-image: url("misc-assets/trash.png");
     height: 150px;
     width: 226px;
-}
-
-.icon-grid {
-    spacing: 36px;
-    -cinnamon-grid-item-size: 118px;
-}
-
-.icon-grid .overview-icon {
-    icon-size: 96px;
-}
-
-.overview-icon {
-    border-radius: 0px;
-    padding: 3px;
-    border: 1px rgba(0, 0, 0, 0);
-    font-size: 7.5pt;
-    color: white;
-    transition-duration: 100;
-    text-align: center;
 }
 
 .expo-background {
@@ -1248,18 +1206,6 @@ StScrollBar StButton#vhandle:hover {
     border-image: url("misc-assets/hover-2.png") 6;
 }
 
-.menu-places-box {
-    padding: 8px;
-    border: 0px solid #666;
-}
-
-.menu-places-button {
-    padding-top: 10px;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-bottom: 10px;
-}
-
 .menu-categories-box {
     padding-top: 10px;
     padding-left: 30px;
@@ -1607,10 +1553,6 @@ StScrollBar StButton#vhandle:hover {
 /* ===================================================================
  * Workspace Switcher applet (workspace-switcher@cinnamon.org/applet.js)
  * ===================================================================*/
-#workspaceSwitcher {
-    spacing: 200px;
-}
-
 .workspace-button {
     width: 20px;
     height: 6px;

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1693,10 +1693,6 @@ StScrollBar StButton#vhandle:hover {
 /* ===================================================================
  * Panel Launchers applet (panel-launchers@cinnamon.org/applet.js)
  * ===================================================================*/
-#panel-launchers-box {
-    padding-left: 0px;
-}
-
 .panel-launchers {
     spacing: 0;
 }
@@ -1728,50 +1724,6 @@ StScrollBar StButton#vhandle:hover {
 
 .panel-right .panel-launchers .launcher:hover {
     border-image: url("panel-assets/hover-1-right.svg") 6;
-}
-
-.panel-launcher-add-dialog-content-box {
-    padding: 6px;
-    spacing: 20px;
-}
-
-.panel-launcher-add-dialog-content-box-left {
-    padding: 6px;
-    spacing: 20px;
-}
-
-.panel-launcher-add-dialog-content-box-right {
-    padding: 6px;
-    spacing: 10px;
-}
-
-.panel-launcher-add-dialog-entry {
-    padding: 4px 12px;
-    color: #2b2b2b;
-    border-image: url("misc-assets/entry.png") 6;
-    border-radius: 4px;
-    caret-color: #2b2b2b;
-    caret-size: 1px;
-    width: 250px;
-    height: 16px;
-    transition-duration: 300;
-    selected-color: #fff;
-    selection-background-color: #accd8a;
-}
-
-.panel-launcher-add-dialog-entry:focus,
-.panel-launcher-add-dialog-entry:hover {
-    padding: 4px 12px;
-    color: #2b2b2b;
-    border-image: url("misc-assets/entry-focus.png") 6;
-    border-radius: 4px;
-    width: 250px;
-    height: 16px;
-    selected-color: #fff;
-    caret-color: #2b2b2b;
-    caret-size: 1px;
-    selection-background-color: #accd8a;
-    transition-duration: 150;
 }
 
 /* ===================================================================

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -162,7 +162,7 @@ StScrollBar StButton#vhandle:hover {
     border-image: url("misc-assets/entry.png") 6;
     border-radius: 4px;
     width: 250px;
-    height: 16px;
+    min-height: 16px;
     selected-color: #fff;
     caret-color: #2b2b2b;
     caret-size: 1px;
@@ -176,7 +176,7 @@ StScrollBar StButton#vhandle:hover {
     border-image: url("misc-assets/entry-focus.png") 6;
     border-radius: 4px;
     width: 250px;
-    height: 16px;
+    min-height: 16px;
     selected-color: #fff;
     caret-color: #2b2b2b;
     caret-size: 1px;

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1526,7 +1526,7 @@ StScrollBar StButton#vhandle:hover {
     width: 22px;
     height: 22px;
     padding: 5px;
-    color: #bbb;
+    color: #464646;
 }
 
 .sound-player StButton:small {
@@ -1535,7 +1535,6 @@ StScrollBar StButton#vhandle:hover {
     width: 16px;
     height: 16px;
     padding: 1px;
-    color: rgb(90, 90, 90);
 }
 
 .sound-player StButton StIcon {
@@ -1548,7 +1547,7 @@ StScrollBar StButton#vhandle:hover {
 
 .sound-player StButton:hover,
 .sound-player StButton:active {
-    color: #fff;
+    color: rgba(70, 70, 70, 0.4);
 }
 
 .sound-player StButton:small:hover {
@@ -1577,16 +1576,24 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .sound-player > StBoxLayout {
-    padding: 5px;
+    padding: 0 16px 8px;
+}
+
+.sound-player > StBoxLayout:first-child {
+    border: 1px solid #c2c2c2;
+    border-top: 0;
+    border-right: 0;
+    border-left: 0;
 }
 
 .sound-player-overlay {
+    border-top: 1px solid #c2c2c2;
     width: 300px;
     height: 70px;
-    padding: 15px;
+    padding: 16px;
     spacing: 0.5em;
-    background: rgba(0, 0, 0, 0.8);
-    color: #FFF;
+    color: #464646;
+    background: #ececec;
 }
 
 .sound-player-overlay StBoxLayout {


### PR DESCRIPTION
### Clean up unused styles.

- Removed **#panel-launcher-box**: This *ID* was removed and replaced with the **panel-launchers** class ([Cinnamon commit](https://github.com/linuxmint/Cinnamon/commit/7158824c25a5ee6a586568ddeb8c4b93e8432239)).
- Removed **.panel-launcher-add-dialog-***: These classes usage were removed [around 2012](https://github.com/linuxmint/Cinnamon/commit/daa013de8ca8e4d22c04b569319dc4a47fa58392).
- Removed **.workspace-controls**, **.workspace-thumbnails-background**, **.workspace-thumbnail-indicator**, **.icon-grid** and **.overview-icon**: These classes usage were removed around 2012 ([#1](https://github.com/linuxmint/Cinnamon/commit/0bdbd02741dacb753bf576e93440d1127b8bdb45), [#2](https://github.com/linuxmint/Cinnamon/commit/379f1663025d0b9dee654a745ab0a79c75e62e19), [#3](https://github.com/linuxmint/Cinnamon/commit/79adc709b9351d880c9b07a8ec1b50ff76d5f44d)).
- Removed **.menu-places-box** and **.menu-places-button**: These two classes seem to never have been applied to any element in the menu applet. The places buttons on the menu uses the generic class **menu-application-button** whcih are placed inside the box with the **menu-applications-box** class.
- Removed **#workspaceSwitcher**: This was removed when the Workspace switcher was converted into a *real applet* [around 2012](https://github.com/linuxmint/Cinnamon/commit/26ab3695e82e7911680df303d1230072cf304107).

### Sound applet: player style homogenization.

- Changed the sound player design to be more in-line with the *design concept* of the Mint-X theme. It didn't made much sense having the sound player with black background and grey elements when every single aspect of the entire theme was having grey backgrounds with black elements.

![soundappletbeforeafter](https://user-images.githubusercontent.com/3822556/38194565-a2bcb8ec-364e-11e8-92fb-7248eb96fed2.png)

### Removed fixed height of entries inside menus.

- Changed the **height** for entries inside menus (**.menu StEntry** selector) to **min-height**. The fixed height destroyed the entry capability to expand vertically on word wrapping and on multi-line text. I resorted to change this properties directly in the theme due to my impossibility to override these fixed sizes programmatically from JavaScript code (from inside an xlet code).
