### PR TITLE
[Mint-X/Cinnamon] Fix modal dialogs button shifting when buttons are focused

### DIFF
--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -939,8 +939,6 @@ StScrollBar StButton#vhandle:hover {
 
 .modal-dialog-button:focus {
     border-image: url("button-assets/button-focus.png") 4;
-    margin-left: 10px;
-    margin-right: 10px;
     padding: 3px 31px 4px;
 }
 
@@ -951,8 +949,6 @@ StScrollBar StButton#vhandle:hover {
 
 .modal-dialog-button:focus:hover {
     border-image: url("button-assets/button-focus-hover.png") 4;
-    margin-left: 10px;
-    margin-right: 10px;
     padding: 3px 31px 4px;
 }
 


### PR DESCRIPTION
The modal dialog buttons (class **modal-dialog-button**) had a left and right margins added when focused (**focus** and **focus:hover** pseudo-classes). I removed the margins so the buttons position is kept when switching focus.

The following animated image illustrates the problem (the **Tab** key is pressed to switch focus):

![ezgif-5-4efc2ff83e](https://user-images.githubusercontent.com/3822556/38509735-28355e0c-3bf9-11e8-963c-4a2c8417ca74.png)

The following animated image illustrates the fixed behavior:

![ezgif-5-a5acdc20f2](https://user-images.githubusercontent.com/3822556/38510398-56c49312-3bfb-11e8-88de-33729dedf26e.png)

**Note:** I opted by removing the margins instead of adding them to the **modal-dialog-button** selector so the alignment of the buttons in relation to the other elements of the dialog are somewhat symmetric.