### PR TITLE
Mint-X (GTK-3): fix «Character Palette» applet's background

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/apps/mate-applications.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/apps/mate-applications.css
@@ -68,7 +68,7 @@ PanelToplevel.background,
     border-style: solid;
     border-width: 2px;
     border-radius: 3px;
-    background-color: transparent;
+    background-color: @theme_bg_color;
     background-image: none;
 }
 
@@ -128,7 +128,7 @@ PanelToplevel.background,
                 inset 1px 0 alpha(black, 0.08),
                 inset -1px 0 alpha(black, 0.08),
                 inset 0 -1px alpha(black, 0.06);
-    background-color: transparent;
+    background-color: @theme_selected_bg_color;
     background-image: linear-gradient(to bottom,
                                       alpha(black, 0.2),
                                       alpha(black, 0.2));


### PR DESCRIPTION
Re-quest for comments: a possible fix – for issue https://github.com/mate-desktop/mate-applets/issues/317.