### PR TITLE
Linux Mint: Remove some unneeded icons sizes

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1474,14 +1474,6 @@ StScrollBar StButton#vhandle:hover {
     color: rgb(200, 200, 200);
 }
 
-.sound-player StButton StIcon {
-    icon-size: 1.5em;
-}
-
-.sound-player StButton:small StIcon {
-    icon-size: 1.2em;
-}
-
 .sound-player StButton:hover,
 .sound-player StButton:active {
     color: #fff;


### PR DESCRIPTION
This was giving us some blurry icons in some cases