### PR TITLE
align tabs, app specific tab coloring,  restore caja sidebar color,  improve pane separator.

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/apps/mate-applications.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/apps/mate-applications.css
@@ -38,6 +38,14 @@ CajaWindow CajaEmblemSidebar GtkViewport {
     border-width: 0px;
 }
 
+.caja-side-pane notebook treeview.view,
+.caja-side-pane notebook textview.view text,
+.caja-side-pane notebook viewport.frame,
+.caja-side-pane notebook widget .vertical {
+    background-color: shade (@caja_sidebar_bg, 1.0);
+    color: @caja_sidebar_fg;
+}
+
 /***********
 * Terminal *
 ************/
@@ -45,6 +53,60 @@ vte-terminal {
     -TerminalScreen-background-darkness: 0.9;
     background-color: #3f3f3f;
     color: #fff;
+}
+
+/**************
+* Mate-Terminal *
+***************/
+
+window.background.mate-terminal > box.vertical > notebook:not(.frame) > stack > box,
+window.background.csd.mate-terminal > box.vertical > notebook:not(.frame) > stack > box,
+window.background.ssd.mate-terminal > box.vertical > notebook:not(.frame) > stack > box,
+window.background.solid-csd.mate-terminal > box.vertical > notebook:not(.frame) > stack > box {
+    border-style: solid;
+    border-width: 0px 1px 1px 1px;
+    border-color: shade(@border, 1.0);
+    margin-right: 0px;
+}
+
+.mate-terminal notebook > header {
+    padding: 0px;
+    margin-right: -2px;
+}
+
+.mate-terminal notebook > header > tabs > tab:checked {
+    background-color: @theme_base_color;
+}
+
+/****************
+ * Pluma *
+ ****************/
+
+.pluma-window notebook > header {
+    padding: 2px;
+    margin-left: -2px;
+    margin-right: -2px;
+    margin-bottom: -3px;
+    padding-bottom: 0;
+}
+
+.pluma-window notebook > header.top > tabs > tab:checked {
+    border-bottom: transparent;
+    background-color: @theme_base_color;
+}
+
+/****************
+ *  pavu-control  *
+ ****************/
+
+window.background > box.vertical > notebook:not(.frame) > stack > box,
+window.background.csd > box.vertical > notebook:not(.frame) > stack > box,
+window.background.ssd > box.vertical > notebook:not(.frame) > stack > box,
+window.background.solid-csd > box.vertical > notebook:not(.frame) > stack > box {
+    border-style: solid;
+    border-width: 0px 1px 1px 1px;
+    border-color: shade(@border, 1.0);
+    margin-right: 0px;
 }
 
 /****************

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1404,6 +1404,7 @@ notebook > header.right > tabs > tab {
     margin-right: 2px;
     border: 1px solid @border;
     border-radius: 0 4px 4px 0;
+    color: @theme_fg_color;
     background-color: transparent;
     background-image: linear-gradient(to bottom,
                                       @notebook_tab_bg_a,

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1292,6 +1292,11 @@ notebook.frame > header {
     margin: -1px;
 }
 
+notebook.frame > header > tabs {
+    margin: 0px;
+    margin-right: -2px;
+}
+
 notebook.frame > header.top {
     margin-bottom: 0;
     padding-left: 0;
@@ -1321,7 +1326,7 @@ notebook > stack:not(:only-child) { /* the :not(:only-child) is for "hidden" not
 }
 
 notebook > header {
-    padding: 2px;
+    padding: 0px;
     background-color: @theme_bg_color;
 }
 
@@ -1349,7 +1354,8 @@ notebook > header.top > tabs > tab {
     padding: 2px 10px;
     min-width: 20px;
     min-height: 20px;
-    margin-left: 3px;
+    margin-left: 0px;
+    margin-right: 2px;
     border: 1px solid @border;
     border-radius: 4px 4px 0 0;
     color: @theme_fg_color;
@@ -1363,12 +1369,13 @@ notebook > header.bottom > tabs > tab {
     padding: 2px 10px;
     min-width: 20px;
     min-height: 20px;
-    margin-left: 3px;
+    margin-left: 0px;
+    margin-right: 2px;
     border: 1px solid @border;
-    border-radius: 0 0 4px 4px;
+    border-radius: 4px 4px 0 0;
     color: @theme_fg_color;
     background-color: transparent;
-    background-image: linear-gradient(to top,
+    background-image: linear-gradient(to bottom,
                                       @notebook_tab_bg_a,
                                       @notebook_tab_bg_b);
 }
@@ -1377,9 +1384,10 @@ notebook > header.left > tabs > tab {
     padding: 2px 10px;
     min-width: 20px;
     min-height: 20px;
-    margin-top: 3px;
+    margin-left: 0px;
+    margin-right: 2px;
     border: 1px solid @border;
-    border-radius: 4px 0 0 4px;
+    border-radius: 4px 4px 0 0;
     color: @theme_fg_color;
     background-color: transparent;
     background-image: linear-gradient(to bottom,
@@ -1391,9 +1399,10 @@ notebook > header.right > tabs > tab {
     padding: 2px 10px;
     min-width: 20px;
     min-height: 20px;
-    margin-top: 3px;
+    margin-left: 0px;
+    margin-right: 2px;
     border: 1px solid @border;
-    border-radius: 0 4px 4px 0;
+    border-radius: 4px 4px 0 0;
     color: @theme_fg_color;
     background-color: transparent;
     background-image: linear-gradient(to bottom,
@@ -1522,52 +1531,20 @@ GtkOverlay.osd {
  ******************/
 
 paned > separator {
-    min-width: 1px;
-    min-height: 1px;
-    -gtk-icon-source: none;
     border-style: none;
+    border-image: none;
+    border-width: 0px;
+    border-radius: 0;
     background-color: transparent;
-    background-image: linear-gradient(to bottom, @border, @border);
-    background-size: 1px 1px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-image: -gtk-scaled(url("assets/pane-separator-grip-vertical.png"), url("assets/pane-separator-grip-vertical@2.png"));
 }
 
-paned > separator.wide {
-    min-width: 5px;
-    min-height: 5px;
-    margin: 0;
-    padding: 0;
-    background-color: transparent;
-}
-
-paned.horizontal > separator.wide {
-    background-size: 2px 24px;
-}
-
-paned.vertical > separator.wide {
-    background-size: 24px 2px;
-}
-
-paned.horizontal > separator {
-    background-repeat: repeat-y;
-}
-
-paned.horizontal > separator:dir(ltr) {
-    margin: 0 -8px 0 0;
-    padding: 0 8px 0 0;
-    background-position: left;
-}
-
-paned.horizontal > separator:dir(rtl) {
-    margin: 0 0 0 -8px;
-    padding: 0 0 0 8px;
-    background-position: right;
-}
-
-paned.vertical > separator {
-    margin: 0 0 -8px 0;
-    padding: 0 0 8px 0;
-    background-repeat: repeat-x;
-    background-position: top;
+paned > separator.vertical {
+    background-image: -gtk-scaled(url("assets/pane-separator-grip.png"), url("assets/pane-separator-grip@2.png"));
+    background-repeat: no-repeat;
+    background-position: center;
 }
 
 /************

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1390,7 +1390,7 @@ notebook > header.left > tabs > tab {
     border-radius: 4px 0 0 4px;
     color: @theme_fg_color;
     background-color: transparent;
-    background-image: linear-gradient(to top,
+    background-image: linear-gradient(to bottom,
                                       @notebook_tab_bg_a,
                                       @notebook_tab_bg_b);
 
@@ -1404,9 +1404,8 @@ notebook > header.right > tabs > tab {
     margin-right: 2px;
     border: 1px solid @border;
     border-radius: 0 4px 4px 0;
-    color: @theme_fg_color;
     background-color: transparent;
-    background-image: linear-gradient(to top,
+    background-image: linear-gradient(to bottom,
                                       @notebook_tab_bg_a,
                                       @notebook_tab_bg_b);
 }

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1372,10 +1372,10 @@ notebook > header.bottom > tabs > tab {
     margin-left: 0px;
     margin-right: 2px;
     border: 1px solid @border;
-    border-radius: 4px 4px 0 0;
+    border-radius: 0 0 4px 4px;
     color: @theme_fg_color;
     background-color: transparent;
-    background-image: linear-gradient(to bottom,
+    background-image: linear-gradient(to top,
                                       @notebook_tab_bg_a,
                                       @notebook_tab_bg_b);
 }
@@ -1387,12 +1387,13 @@ notebook > header.left > tabs > tab {
     margin-left: 0px;
     margin-right: 2px;
     border: 1px solid @border;
-    border-radius: 4px 4px 0 0;
+    border-radius: 4px 0 0 4px;
     color: @theme_fg_color;
     background-color: transparent;
-    background-image: linear-gradient(to bottom,
+    background-image: linear-gradient(to top,
                                       @notebook_tab_bg_a,
                                       @notebook_tab_bg_b);
+
 }
 
 notebook > header.right > tabs > tab {
@@ -1402,10 +1403,10 @@ notebook > header.right > tabs > tab {
     margin-left: 0px;
     margin-right: 2px;
     border: 1px solid @border;
-    border-radius: 4px 4px 0 0;
+    border-radius: 0 4px 4px 0;
     color: @theme_fg_color;
     background-color: transparent;
-    background-image: linear-gradient(to bottom,
+    background-image: linear-gradient(to top,
                                       @notebook_tab_bg_a,
                                       @notebook_tab_bg_b);
 }
@@ -1531,20 +1532,52 @@ GtkOverlay.osd {
  ******************/
 
 paned > separator {
+    min-width: 1px;
+    min-height: 1px;
+    -gtk-icon-source: none;
     border-style: none;
-    border-image: none;
-    border-width: 0px;
-    border-radius: 0;
     background-color: transparent;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-image: -gtk-scaled(url("assets/pane-separator-grip-vertical.png"), url("assets/pane-separator-grip-vertical@2.png"));
+    background-image: linear-gradient(to bottom, @border, @border);
+    background-size: 1px 1px;
 }
 
-paned > separator.vertical {
-    background-image: -gtk-scaled(url("assets/pane-separator-grip.png"), url("assets/pane-separator-grip@2.png"));
-    background-repeat: no-repeat;
-    background-position: center;
+paned > separator.wide {
+    min-width: 5px;
+    min-height: 5px;
+    margin: 0;
+    padding: 0;
+    background-color: transparent;
+}
+
+paned.horizontal > separator.wide {
+    background-size: 2px 24px;
+}
+
+paned.vertical > separator.wide {
+    background-size: 24px 2px;
+}
+
+paned.horizontal > separator {
+    background-repeat: repeat-y;
+}
+
+paned.horizontal > separator:dir(ltr) {
+    margin: 0 -8px 0 0;
+    padding: 0 8px 0 0;
+    background-position: left;
+}
+
+paned.horizontal > separator:dir(rtl) {
+    margin: 0 0 0 -8px;
+    padding: 0 0 0 8px;
+    background-position: right;
+}
+
+paned.vertical > separator {
+    margin: 0 0 -8px 0;
+    padding: 0 0 8px 0;
+    background-repeat: repeat-x;
+    background-position: top;
 }
 
 /************


### PR DESCRIPTION
I played around with different ways to align all the tabs with the frame correctly, but the below code was what I found to correctly align all programs.  I tried various ways but there was always a program or too that was just a little off.  This code below should correctly align all programs, unless I missed checking one.  

I restored the caja side panel coloring like it was in gtk-3.18.

I changed the checked/selected tabs in pluma and mate-terminal to theme-base-color and made the bottom border transparent, this way they correctly blend into the frame window seamlessly. 

I restored the frame border to pulseaudio volume control.

And lastly I restored the pane separator to its 3.18 look, it now has the correct icon and spacing, this looks right on every program I checked, but please review the code, because I wasn't 100% sure this was the best way to restore it the way it looked in 3.18.

 