### PR TITLE
remove perforated lines around borders

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -2024,7 +2024,7 @@ undershoot.top {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-top: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center top; }
@@ -2033,7 +2033,7 @@ undershoot.bottom {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-bottom: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center bottom; }
@@ -2042,7 +2042,7 @@ undershoot.left {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-left: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: left center; }
@@ -2051,7 +2051,7 @@ undershoot.right {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-right: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: right center; }

--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -2183,7 +2183,7 @@ scrolledwindow undershoot.top {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-top: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center top; }
@@ -2191,7 +2191,7 @@ scrolledwindow undershoot.bottom {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-bottom: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center bottom; }
@@ -2199,7 +2199,7 @@ scrolledwindow undershoot.left {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-left: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: left center; }
@@ -2207,7 +2207,7 @@ scrolledwindow undershoot.right {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-right: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: right center; }

--- a/src/Mint-Y/gtk-3.0/gtk-darker.css
+++ b/src/Mint-Y/gtk-3.0/gtk-darker.css
@@ -2182,7 +2182,7 @@ scrolledwindow undershoot.top {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-top: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center top; }
@@ -2190,7 +2190,7 @@ scrolledwindow undershoot.bottom {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-bottom: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center bottom; }
@@ -2198,7 +2198,7 @@ scrolledwindow undershoot.left {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-left: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: left center; }
@@ -2206,7 +2206,7 @@ scrolledwindow undershoot.right {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-right: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: right center; }

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -2186,7 +2186,7 @@ scrolledwindow undershoot.top {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-top: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center top; }
@@ -2194,7 +2194,7 @@ scrolledwindow undershoot.bottom {
   background-color: transparent;
   background-image: linear-gradient(to left, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-bottom: 1px;
-  background-size: 10px 1px;
+  background-size: 10px 0px;
   background-repeat: repeat-x;
   background-origin: content-box;
   background-position: center bottom; }
@@ -2202,7 +2202,7 @@ scrolledwindow undershoot.left {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-left: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: left center; }
@@ -2210,7 +2210,7 @@ scrolledwindow undershoot.right {
   background-color: transparent;
   background-image: linear-gradient(to top, rgba(255, 255, 255, 0.2) 50%, rgba(0, 0, 0, 0.2) 50%);
   padding-right: 1px;
-  background-size: 1px 10px;
+  background-size: 0px 10px;
   background-repeat: repeat-y;
   background-origin: content-box;
   background-position: right center; }

--- a/src/Mint-Y/gtk-3.0/sass/_drawing.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_drawing.scss
@@ -354,7 +354,7 @@
   $_undershoot_color_light: transparentize(white, 0.8);
 
   $_gradient_dir: left;
-  $_dash_bg_size: 10px 1px;
+  $_dash_bg_size: 10px 0px;
   $_gradient_repeat: repeat-x;
   $_bg_pos: center $p;
 
@@ -362,7 +362,7 @@
 
   @if ($p == left) or ($p == right) {
     $_gradient_dir: top;
-    $_dash_bg_size: 1px 10px;
+    $_dash_bg_size: 0px 10px;
     $_gradient_repeat: repeat-y;
     $_bg_pos: $p center;
   }


### PR DESCRIPTION
When scrolling perforated lines appear in the windows,  this has been around since at least the gtk 3.18 themes.  Lets go ahead and fix them.  See screenshots for better explanation. 

![1](https://user-images.githubusercontent.com/28424337/40468767-f758df3e-5ef3-11e8-87c9-953b768ee1ce.png)
![2](https://user-images.githubusercontent.com/28424337/40468768-f76c16d0-5ef3-11e8-928b-82aa4e4579b0.png)

