### PR TITLE
Restore previous pane separator look

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets-assets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets-assets.css
@@ -159,7 +159,19 @@ menuitem radio:checked:disabled {
  * pane separator *
  ******************/
 
-paned.horizontal > separator.wide {
+paned > separator {
+    background-image: -gtk-scaled(url("assets/pane-separator-grip-vertical.png"), url("assets/pane-separator-grip-vertical@2.png"));
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+paned.vertical > separator {
+    background-image: -gtk-scaled(url("assets/pane-separator-grip.png"), url("assets/pane-separator-grip@2.png"));
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+paned > separator.wide {
     background-image: -gtk-scaled(url("assets/pane-separator-grip-vertical.png"), url("assets/pane-separator-grip-vertical@2.png"));
     background-repeat: no-repeat;
     background-position: center;

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1540,52 +1540,13 @@ GtkOverlay.osd {
  ******************/
 
 paned > separator {
-    min-width: 1px;
-    min-height: 1px;
-    -gtk-icon-source: none;
     border-style: none;
     background-color: transparent;
-    background-image: linear-gradient(to bottom, @border, @border);
-    background-size: 1px 1px;
 }
 
 paned > separator.wide {
-    min-width: 5px;
-    min-height: 5px;
-    margin: 0;
-    padding: 0;
+    border-style: none;
     background-color: transparent;
-}
-
-paned.horizontal > separator.wide {
-    background-size: 2px 24px;
-}
-
-paned.vertical > separator.wide {
-    background-size: 24px 2px;
-}
-
-paned.horizontal > separator {
-    background-repeat: repeat-y;
-}
-
-paned.horizontal > separator:dir(ltr) {
-    margin: 0 -8px 0 0;
-    padding: 0 8px 0 0;
-    background-position: left;
-}
-
-paned.horizontal > separator:dir(rtl) {
-    margin: 0 0 0 -8px;
-    padding: 0 0 0 8px;
-    background-position: right;
-}
-
-paned.vertical > separator {
-    margin: 0 0 -8px 0;
-    padding: 0 0 8px 0;
-    background-repeat: repeat-x;
-    background-position: top;
 }
 
 /************


### PR DESCRIPTION
I've done a few different ways to make this work for about a week, but I've just simplified it and basically just done a port over of the code from the 3.18 theme.  However @JosephMcc mentioned that we need to add code for situations where an gtk app wants the wide style separator so I have added the code for that.  I also looked at greenlaguna theme to see how they were coding they're separator, since the two are similar.  Oddly, the code as it is now works in Xfce, but is not working correctly in Mate or Cinnamon.  Here is a screenshot how it looks now with mate...

![pane4](https://user-images.githubusercontent.com/28424337/40898235-b1b5af3a-6785-11e8-8e4f-ae3d79c5a8aa.png)

You'll see how there is really no separation between the side pane and the window.   With this pull request Ive got Xfce, mate, and cinnamon all looking like they previously did in 3.18.  If you think I need to adjust the code any please let me know, but this should be all we need to get it working correctly. 

Mate

![pane1](https://user-images.githubusercontent.com/28424337/40898272-e0f6d300-6785-11e8-9766-7559edb264e7.png)

Xfce

![pane2](https://user-images.githubusercontent.com/28424337/40898280-f12fe0b8-6785-11e8-9b1a-32bd77228071.png)

Cinnamon

![pane3](https://user-images.githubusercontent.com/28424337/40898288-fcf1cb50-6785-11e8-84f8-e6ff849d6c91.png)



