### PR TITLE
restore top scroll indicator in pluma

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/apps/mate-applications.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/apps/mate-applications.css
@@ -97,7 +97,7 @@ window.background.solid-csd.mate-terminal > box.vertical > notebook:not(.frame) 
     padding: 2px;
     margin-left: -2px;
     margin-right: -2px;
-    margin-bottom: -3px;
+    margin-bottom: -1px;
     padding-bottom: 0;
 }
 


### PR DESCRIPTION
In pluma the header bottom margin is covering the scroll indicator.  So I moved it up a few pixels to restore the scroll indicator back into view.

![scroll](https://user-images.githubusercontent.com/28424337/40958791-2a0d7fb4-6860-11e8-9187-e8fbdcf8d5aa.png)
