### PR TITLE
Update old class name

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1234,7 +1234,11 @@ StScrollBar StButton#vhandle:hover {
     padding-bottom: 10px;
 }
 
-.menu-applications-box {
+.menu-applications-outer-box {
+    padding: 0px 10px;
+}
+
+.menu-applications-inner-box {
     padding-top: 10px;
     padding-left: 10px;
     padding-right: 10px;

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1209,7 +1209,11 @@ StScrollBar StButton#vhandle:hover {
     padding-bottom: 10px;
 }
 
-.menu-applications-box {
+.menu-applications-outer-box {
+    padding: 0px 10px;
+}
+
+.menu-applications-inner-box {
     padding-top: 10px;
     padding-left: 10px;
     padding-right: 10px;


### PR DESCRIPTION
Extra code is used to support this class, and will eventually be removed I guess.

See this line: https://github.com/linuxmint/Cinnamon/blob/c097e0d96ee9887561288b9aa4b96047eb1ee983/files/usr/share/cinnamon/applets/menu%40cinnamon.org/applet.js#L2804