### PR TITLE
Give the grouped window list applet unique class names

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1513,16 +1513,162 @@ StScrollBar StButton#vhandle:hover {
 .grouped-window-list-thumbnail-alert {
     background: rgba(255,52,52,0.3);
 }
-.grouped-window-list-thumbnail-icon {
+
+.grouped-window-list-item-box {
+    color: rgba(255, 255, 255, 1.0);
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(100, 100, 100, 0.5);
+    background-gradient-end: rgba(50, 50, 50, 0.5);
+    box-shadow: inset 0px 0px 0px 1px rgba(80, 80, 80, 0.5);
+    border-radius: 4px 4px 0px 0px;
+    padding: 1px;
+    padding-left: 5px;
+    padding-right: 5px;
+    transition-duration: 100;
+    spacing: 0.5em;
 }
-.window-list-item-box:closed {
-    background-gradient-direction: vertical !important;
-    background-gradient-start: rgba(0,0,0,0.0) !important;
-    background-gradient-end: rgba(0,0,0,0.0) !important;
-    border-radius: 0px 0px 0px 0px !important;
-    border-image: none !important;
-    border-color: rgba(0,0,0,0.0) !important;
-    box-shadow: inset 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
+
+.grouped-window-list-item-box.top {
+    border-radius: 0 0 4px 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+.grouped-window-list-item-box.left {
+    border-radius: 0 4px 4px 0;
+    padding-left: 0;
+    padding-right: 2px;
+}
+
+.grouped-window-list-item-box.right {
+    border-radius: 4px 0 0 4px;
+    padding-left: 2px;
+    padding-right: 0;
+}
+
+.grouped-window-list-item-box.top,
+.grouped-window-list-item-box.bottom {
+    padding: 0 0.5em;
+}
+
+.grouped-window-list-item-box:checked,
+.grouped-window-list-item-box:active:focus:hover,
+.grouped-window-list-item-box:active:hover,
+.grouped-window-list-item-box:focus:hover {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(220, 220, 220, 0.5);
+    background-gradient-end: rgba(70, 70, 70, 0.5);
+    box-shadow: inset 0px 0px 0px 1px rgba(100, 100, 100, 0.9);
+}
+
+.grouped-window-list-item-box:focus,
+.grouped-window-list-item-box:active:focus {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(220, 220, 220, 0.3);
+    background-gradient-end: rgba(70, 70, 70, 0.3);
+    box-shadow: inset 0px 0px 0px 1px rgba(100, 100, 100, 0.5);
+}
+
+.grouped-window-list-item-box:focus:hover {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(220, 220, 220, 0.5);
+    background-gradient-end: rgba(70, 70, 70, 0.5);
+    box-shadow: inset 0px 0px 0px 1px rgba(100, 100, 100, 0.5);
+}
+
+.grouped-window-list-item-box:hover {
+    box-shadow: inset 0px 0px 0px 1px rgba(120, 120, 120, 0.5);
+}
+
+.grouped-window-list-item-box:active {
+    box-shadow: inset 0px 0px 0px 1px rgba(120, 120, 120, 0.3);
+}
+
+.grouped-window-list-item-box:closed {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(0,0,0,0.0);
+    background-gradient-end: rgba(0,0,0,0.0);
+    border-radius: 0px 0px 0px 0px;
+    border-image: none;
+    border-color: rgba(0,0,0,0.0);
+    box-shadow: inset 0px 0px 0px 0px rgba(0,0,0,0.0);
+}
+
+.grouped-window-list-item-demands-attention {
+    background-gradient-start: rgba(255, 52, 52, 0.5);
+    background-gradient-end: rgba(255, 144, 144, 0.5);
+}
+
+.grouped-window-list-preview {
+    border: 1px solid rgba(50, 50, 50, 1);
+    border-radius: 4px;
+    background-color: rgba(63, 63, 63, 0.95);
+    color: #fff;
+    font-size: 9.5pt;
+    padding: 6px 12px 12px 12px;
+    spacing: 0.5em;
+}
+
+.grouped-window-list-item-box .progress {
+    border-radius: 4px 4px 0 0;
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(172, 205, 138, 0.5);
+    background-gradient-end: rgba(172, 205, 138, 0.9);
+}
+
+.panel-top .grouped-window-list-item-box .progress {
+    border-radius: 0 0 4px 4px;
+}
+
+.panel-left .grouped-window-list-item-box .progress {
+    border-radius: 0 4px 4px 0;
+}
+
+.panel-right .grouped-window-list-item-box .progress {
+    border-radius: 4px 0 0 4px;
+}
+
+.grouped-window-list-thumbnail-menu {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(70, 70, 70, 1);
+    background-gradient-end: rgba(50, 50, 50, 1);
+    border-radius: 8px;
+    padding: 20px;
+    font-size: 9pt;
+    color: white;
+    box-shadow: 0px 0px 12px 6px rgba(0, 0, 0, 1);
+}
+
+.grouped-window-list-thumbnail-menu .item-box {
+    padding: 8px;
+    border: 1px solid rgba(0, 0, 0, 0);
+    border-radius: 8px;
+}
+
+.grouped-window-list-thumbnail-menu .item-box:outlined {
+    padding: 6px;
+    border: 2px solid rgba(85, 85, 85, 1.0);
+}
+
+.grouped-window-list-thumbnail-menu .item-box:selected {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(90, 90, 90, 1);
+    background-gradient-end: rgba(70, 70, 70, 1);
+    border: 1px solid rgba(120, 120, 120, 1);
+}
+
+.grouped-window-list-thumbnail-menu .thumbnail-box {
+    padding: 2px;
+    spacing: 4px;
+}
+
+.grouped-window-list-thumbnail-menu .thumbnail {
+    width: 256px;
+}
+
+.grouped-window-list-thumbnail-menu .separator {
+    width: 1px;
+    background: rgba(255, 255, 255, 0.33);
 }
 
 /* ===================================================================

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1477,16 +1477,170 @@ StScrollBar StButton#vhandle:hover {
 .grouped-window-list-thumbnail-alert {
     background: rgba(255,52,52,0.3);
 }
-.grouped-window-list-thumbnail-icon {
+
+.grouped-window-list-item-label {
+    width: 15em;
+    min-width: 5px;
 }
-.window-list-item-box:closed {
-    background-gradient-direction: vertical !important;
-    background-gradient-start: rgba(0,0,0,0.0) !important;
-    background-gradient-end: rgba(0,0,0,0.0) !important;
-    border-radius: 0px 0px 0px 0px !important;
-    border-image: none !important;
-    border-color: rgba(0,0,0,0.0) !important;
-    box-shadow: inset 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
+
+.grouped-window-list-item-box {
+    font-weight: bold;
+    color: rgb(62, 62, 62);
+    padding-top: 1px;
+    padding-left: 4px;
+    padding-right: 4px;
+    border-image: url("panel-assets/hover-3.svg") 6;
+}
+
+.panel-top .grouped-window-list-item-box {
+    border-image: url("panel-assets/hover-3-top.svg") 6;
+}
+
+.panel-left .grouped-window-list-item-box {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-image: url("panel-assets/hover-3-left.svg") 6;
+}
+
+.panel-right .grouped-window-list-item-box {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-image: url("panel-assets/hover-3-right.svg") 6;
+}
+
+.grouped-window-list-item-box:active,
+.grouped-window-list-item-box:active:hover,
+.grouped-window-list-item-box:checked,
+.grouped-window-list-item-box:checked:hover,
+.grouped-window-list-item-box:hover {
+    border-image: url("panel-assets/hover-1.svg") 6;
+}
+
+.panel-top .grouped-window-list-item-box:hover {
+    border-image: url("panel-assets/hover-1-top.svg") 6;
+}
+
+.panel-left .grouped-window-list-item-box:hover {
+    border-image: url("panel-assets/hover-1-left.svg") 6;
+}
+
+.panel-right .grouped-window-list-item-box:hover {
+    border-image: url("panel-assets/hover-1-right.svg") 6;
+}
+
+.grouped-window-list-item-box:focus,
+.grouped-window-list-item-box:focus:hover,
+.grouped-window-list-item-box:focus:active:hover {
+    font-weight: bold;
+    color: #fff;
+    border-image: url("panel-assets/pressed.svg") 6;
+}
+
+.grouped-window-list-item-box:closed {
+    background-gradient-direction: vertical;
+    background-gradient-start: rgba(0,0,0,0.0);
+    background-gradient-end: rgba(0,0,0,0.0);
+    border-radius: 0px 0px 0px 0px;
+    border-image: none;
+    border-color: rgba(0,0,0,0.0);
+    box-shadow: inset 0px 0px 0px 0px rgba(0,0,0,0.0);
+}
+
+.panel-top .grouped-window-list-item-box:active,
+.panel-top .grouped-window-list-item-box:checked,
+.panel-top .grouped-window-list-item-box:focus,
+.panel-top .grouped-window-list-item-box:checked:hover,
+.panel-top .grouped-window-list-item-box:focus:hover,
+.panel-top .grouped-window-list-item-box:active:hover {
+    border-image: url("panel-assets/pressed-top.svg") 6;
+}
+
+.panel-left .grouped-window-list-item-box:active,
+.panel-left .grouped-window-list-item-box:checked,
+.panel-left .grouped-window-list-item-box:focus,
+.panel-left .grouped-window-list-item-box:checked:hover,
+.panel-left .grouped-window-list-item-box:focus:hover,
+.panel-left .grouped-window-list-item-box:active:hover {
+    border-image: url("panel-assets/pressed-left.svg") 6;
+}
+
+.panel-right .grouped-window-list-item-box:active,
+.panel-right .grouped-window-list-item-box:checked,
+.panel-right .grouped-window-list-item-box:focus,
+.panel-right .grouped-window-list-item-box:checked:hover,
+.panel-right .grouped-window-list-item-box:focus:hover,
+.panel-right .grouped-window-list-item-box:active:hover {
+    border-image: url("panel-assets/pressed-right.svg") 6;
+}
+
+.grouped-window-list-item-demands-attention {
+    border-image: url("panel-assets/attention.svg") 6;
+}
+
+.panel-top .grouped-window-list-item-demands-attention {
+    border-image: url("panel-assets/attention-top.svg") 6;
+}
+
+.panel-left .grouped-window-list-item-demands-attention {
+    border-image: url("panel-assets/attention-left.svg") 6;
+}
+
+.panel-right .grouped-window-list-item-demands-attention {
+    border-image: url("panel-assets/attention-right.svg") 6;
+}
+
+.grouped-window-list-item-box .progress {
+    border-image: url("panel-assets/progress.svg") 6;
+}
+
+.panel-top .grouped-window-list-item-box .progress {
+    border-image: url("panel-assets/progress-top.svg") 6;
+}
+
+.panel-left .grouped-window-list-item-box .progress {
+    border-image: url("panel-assets/progress-left.svg") 6;
+}
+
+.panel-right .grouped-window-list-item-box .progress {
+    border-image: url("panel-assets/progress-right.svg") 6;
+}
+
+.grouped-window-list-thumbnail-menu {
+    border-image: url("background-assets/bg-1.png") 6;
+    color: rgb(70, 70, 70);
+    padding: 20px;
+    font-size: 9pt;
+    font-weight: bold;
+}
+
+.grouped-window-list-thumbnail-menu .item-box {
+    padding: 8px;
+    border: 1px solid rgba(0, 0, 0, 0);
+    border-radius: 0px;
+}
+
+.grouped-window-list-thumbnail-menu .item-box:outlined {
+    padding: 6px;
+    border: 2px solid rgba(85, 85, 85, 0);
+}
+
+.grouped-window-list-thumbnail-menu .item-box:selected {
+    border-image: url("misc-assets/hover-2.png") 6;
+    color: #fff;
+}
+
+.grouped-window-list-thumbnail-menu .thumbnail-box {
+    padding: 2px;
+    spacing: 4px;
+}
+
+.grouped-window-list-thumbnail-menu .thumbnail {
+    width: 256px;
+}
+
+.grouped-window-list-thumbnail-menu .separator {
+    width: 1px;
+    background: rgba(255, 255, 255, 0.33);
 }
 
 /* ===================================================================

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1128,6 +1128,49 @@ StScrollBar {
   padding: 6px 12px 12px 12px;
   font-size: 1em; }
 
+.grouped-window-list-item-label {
+  font-weight: bold;
+  width: 15em;
+  min-width: 5px; }
+.grouped-window-list-item-box {
+  font-weight: bold;
+  background-image: none;
+  padding-top: 0;
+  padding-left: 8px;
+  padding-right: 8px;
+  transition-duration: 100;
+  color: rgba(255, 255, 255, 0.6); }
+  .grouped-window-list-item-box.top, .grouped-window-list-item-box.bottom {
+    border-bottom-width: 2px; }
+    .grouped-window-list-item-box.top StLabel, .grouped-window-list-item-box.bottom StLabel {
+      padding-left: 2px; }
+  .grouped-window-list-item-box.right {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-right-width: 2px; }
+    .grouped-window-list-item-box.right StBin {
+      padding-right: 0; }
+  .grouped-window-list-item-box.left {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-left-width: 2px; }
+    .grouped-window-list-item-box.left StBin {
+      padding-left: 1px; }
+  .grouped-window-list-item-box:hover, .grouped-window-list-item-box:focus {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.1); }
+  .grouped-window-list-item-box:focus:hover {
+    color: #ffffff;
+    background-color: selected_fg_color; }
+  .grouped-window-list-item-box:active, .grouped-window-list-item-box:checked {
+    color: #ffffff;
+    border-color: #8fa876; }
+  .grouped-window-list-item-box .progress {
+    background-color: rgba(143, 168, 118, 0.8); }
+.grouped-window-list-item-demands-attention {
+  background-gradient-direction: vertical;
+  background-gradient-start: #F04A50;
+  background-gradient-end: #F04A50; }
 .grouped-window-list-thumbnail-label {
   padding-left: 4px; }
 .grouped-window-list-number-label {
@@ -1137,6 +1180,32 @@ StScrollBar {
   padding-left: 4px; }
 .grouped-window-list-thumbnail-alert {
   background: rgba(255, 52, 52, 0.3); }
+.grouped-window-list-thumbnail-menu {
+  color: #D3D3D3;
+  border: 1px solid #202020;
+  background-color: #2f2f2f;
+  border-radius: 3px;
+  padding: 20px; }
+  .grouped-window-list-thumbnail-menu > StBoxLayout {
+    padding: 4px; }
+  .grouped-window-list-thumbnail-menu .item-box {
+    padding: 8px;
+    border-radius: 2px; }
+    .grouped-window-list-thumbnail-menu .item-box:outlined {
+      padding: 8px;
+      border: 1px solid #8fa876; }
+    .grouped-window-list-thumbnail-menu .item-box:selected {
+      color: #ffffff;
+      background-color: #8fa876;
+      border: 0px solid #8fa876; }
+  .grouped-window-list-thumbnail-menu .thumbnail {
+    width: 256px; }
+  .grouped-window-list-thumbnail-menu .thumbnail-box {
+    padding: 2px;
+    spacing: 4px; }
+  .grouped-window-list-thumbnail-menu .separator {
+    width: 1px;
+    background: rgba(255, 255, 255, 0.2); }
 
 .sound-button {
   width: 22px;

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1128,6 +1128,49 @@ StScrollBar {
   padding: 6px 12px 12px 12px;
   font-size: 1em; }
 
+.grouped-window-list-item-label {
+  font-weight: bold;
+  width: 15em;
+  min-width: 5px; }
+.grouped-window-list-item-box {
+  font-weight: bold;
+  background-image: none;
+  padding-top: 0;
+  padding-left: 8px;
+  padding-right: 8px;
+  transition-duration: 100;
+  color: rgba(255, 255, 255, 0.6); }
+  .grouped-window-list-item-box.top, .grouped-window-list-item-box.bottom {
+    border-bottom-width: 2px; }
+    .grouped-window-list-item-box.top StLabel, .grouped-window-list-item-box.bottom StLabel {
+      padding-left: 2px; }
+  .grouped-window-list-item-box.right {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-right-width: 2px; }
+    .grouped-window-list-item-box.right StBin {
+      padding-right: 0; }
+  .grouped-window-list-item-box.left {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-left-width: 2px; }
+    .grouped-window-list-item-box.left StBin {
+      padding-left: 1px; }
+  .grouped-window-list-item-box:hover, .grouped-window-list-item-box:focus {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.1); }
+  .grouped-window-list-item-box:focus:hover {
+    color: #ffffff;
+    background-color: selected_fg_color; }
+  .grouped-window-list-item-box:active, .grouped-window-list-item-box:checked {
+    color: #ffffff;
+    border-color: #9ab87c; }
+  .grouped-window-list-item-box .progress {
+    background-color: rgba(154, 184, 124, 0.8); }
+.grouped-window-list-item-demands-attention {
+  background-gradient-direction: vertical;
+  background-gradient-start: #F04A50;
+  background-gradient-end: #F04A50; }
 .grouped-window-list-thumbnail-label {
   padding-left: 4px; }
 .grouped-window-list-number-label {
@@ -1137,6 +1180,32 @@ StScrollBar {
   padding-left: 4px; }
 .grouped-window-list-thumbnail-alert {
   background: rgba(255, 52, 52, 0.3); }
+.grouped-window-list-thumbnail-menu {
+  color: #4a4a4a;
+  border: 1px solid #d9d9d9;
+  background-color: #F0F0F0;
+  border-radius: 3px;
+  padding: 20px; }
+  .grouped-window-list-thumbnail-menu > StBoxLayout {
+    padding: 4px; }
+  .grouped-window-list-thumbnail-menu .item-box {
+    padding: 8px;
+    border-radius: 2px; }
+    .grouped-window-list-thumbnail-menu .item-box:outlined {
+      padding: 8px;
+      border: 1px solid #9ab87c; }
+    .grouped-window-list-thumbnail-menu .item-box:selected {
+      color: #ffffff;
+      background-color: #9ab87c;
+      border: 0px solid #9ab87c; }
+  .grouped-window-list-thumbnail-menu .thumbnail {
+    width: 256px; }
+  .grouped-window-list-thumbnail-menu .thumbnail-box {
+    padding: 2px;
+    spacing: 4px; }
+  .grouped-window-list-thumbnail-menu .separator {
+    width: 1px;
+    background: rgba(255, 255, 255, 0.2); }
 
 .sound-button {
   width: 22px;

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1491,6 +1491,72 @@ StScrollBar {
 
 .grouped-window-list {
 
+  &-item-label {
+    font-weight: bold;
+    width: 15em;
+    min-width: 5px;
+  }
+
+  &-item-box {
+    font-weight: bold;
+    background-image: none;
+    padding-top: 0;
+    padding-left: 8px;
+    padding-right: 8px;
+    transition-duration: 100;
+    color: transparentize($selected_fg_color, 0.4);
+
+    &.top,
+    &.bottom {
+      border-bottom-width: 2px;
+
+      & StLabel { padding-left: 2px; }
+    }
+
+    &.right {
+      padding-left: 0px;
+      padding-right: 0px;
+      border-right-width: 2px;
+
+      & StBin { padding-right: 0; }
+    }
+
+    &.left {
+      padding-left: 0px;
+      padding-right: 0px;
+      border-left-width: 2px;
+
+      & StBin { padding-left: 1px; }
+    }
+
+    &:hover,
+    &:focus {
+      color: $selected_fg_color;
+      background-color: transparentize($selected_fg_color, 0.9);
+    }
+
+    &:focus:hover {
+      color: $selected_fg_color;
+      background-color: selected_fg_color;
+    }
+
+    &:active,
+    &:checked {
+      color: $selected_fg_color;
+      border-color: $selected_bg_color;
+    }
+
+    & .progress {
+      background-color: transparentize($selected_bg_color, 0.2);
+    }
+  }
+
+  &-item-demands-attention {
+    background-gradient-direction: vertical;
+    background-gradient-start: $destructive_color;
+    background-gradient-end: $destructive_color;
+  }
+
   &-thumbnail-label {
     padding-left: 4px;
   }
@@ -1508,7 +1574,43 @@ StScrollBar {
     background: rgba(255,52,52,0.3);
   }
 
-  &-thumbnail-icon {
+  &-thumbnail-menu {
+    color: $fg_color;
+    border: 1px solid $borders_color;
+    background-color: $bg_color;
+    border-radius: 3px;
+    padding: 20px;
+
+    > StBoxLayout {
+      padding: 4px;
+    }
+
+    .item-box {
+      padding: 8px;
+      border-radius: 2px;
+
+      &:outlined {
+        padding: 8px;
+        border: 1px solid $selected_bg_color;
+      }
+
+      &:selected {
+        color: $selected_fg_color;
+        background-color: $selected_bg_color;
+        border: 0px solid $selected_bg_color;
+      }
+    }
+
+    .thumbnail { width: 256px; }
+
+    .thumbnail-box {
+      padding: 2px;
+      spacing: 4px;
+    }
+    .separator {
+      width: 1px;
+      background: rgba(255,255,255,0.2);
+    }
   }
 }
 


### PR DESCRIPTION
Also some minor improvement for the Linux Mint theme to distinguish between active hovered and focus hovered, instead of just switching to hover style. Since Mint-X uses SVGs, I wasn't sure how to do the same there.