### PR TITLE
Mint-Y & Mint-X Fix Attached Dialog Titlebar

### DIFF
--- a/files/usr/share/themes/Mint-X/metacity-1/metacity-theme-3.xml
+++ b/files/usr/share/themes/Mint-X/metacity-1/metacity-theme-3.xml
@@ -86,10 +86,6 @@
 </frame_geometry>
 
 <frame_geometry name="attached" title_scale="medium" hide_buttons="true" rounded_top_left="4" rounded_top_right="4" rounded_bottom_left="4" rounded_bottom_right="4" parent="normal">
-	<distance name="title_vertical_pad" value="0"/>
-	<distance name="bottom_height" value="3"/>
-	<distance name="left_width" value="3"/>
-	<distance name="right_width" value="3"/>
 </frame_geometry>
 
 <!-- ::: BACKGROUND ::: -->
@@ -546,6 +542,10 @@
 </frame_style>
 
 <frame_style name="attached_unfocused" geometry="attached">
+	<piece position="entire_background" draw_ops="entire_background_unfocused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+	<piece position="title" draw_ops="title_unfocused" />
+	<piece position="overlay" draw_ops="rounded_border_unfocused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
 	<button function="close" state="pressed"><draw_ops></draw_ops></button>
 	<button function="maximize" state="normal"><draw_ops></draw_ops></button>
@@ -569,6 +569,10 @@
 </frame_style>
 
 <frame_style name="attached_focused" geometry="attached">
+	<piece position="entire_background" draw_ops="entire_background_focused" />
+	<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+	<piece position="title" draw_ops="title_focused" />
+	<piece position="overlay" draw_ops="rounded_border_focused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
 	<button function="close" state="pressed"><draw_ops></draw_ops></button>
 	<button function="maximize" state="normal"><draw_ops></draw_ops></button>

--- a/src/Mint-Y/metacity-1/metacity-theme-3-dark.xml
+++ b/src/Mint-Y/metacity-1/metacity-theme-3-dark.xml
@@ -112,12 +112,8 @@
 	<distance name="title_vertical_pad" value="5"/>
 </frame_geometry>
 
-<!--chromium save dialog-->
-<frame_geometry name="attached" title_scale="small" has_title="false"  hide_buttons="true" rounded_top_left="1" rounded_top_right="1" rounded_bottom_left="0" rounded_bottom_right="0" parent="normal">
-	<distance name="title_vertical_pad" value="0"/>
-	<distance name="bottom_height" value="1"/>
-	<distance name="left_width" value="1"/>
-	<distance name="right_width" value="1"/>
+<frame_geometry name="attached" title_scale="small" hide_buttons="true" rounded_top_left="1" rounded_top_right="1" parent="small">
+	<distance name="title_vertical_pad" value="5"/>
 </frame_geometry>
 
 <!-- drawing operations -->
@@ -931,6 +927,7 @@
 <frame_style name="attached_focused" geometry="attached">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
 	<piece position="titlebar" draw_ops="titlebar_focused" />
+	<piece position="title" draw_ops="title_focused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
 	<button function="close" state="pressed"><draw_ops></draw_ops></button>
 	<button function="maximize" state="normal"><draw_ops></draw_ops></button>
@@ -956,6 +953,7 @@
 <frame_style name="attached_unfocused" geometry="attached">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
 	<piece position="titlebar" draw_ops="titlebar_unfocused" />
+	<piece position="title" draw_ops="title_unfocused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
 	<button function="close" state="pressed"><draw_ops></draw_ops></button>
 	<button function="maximize" state="normal"><draw_ops></draw_ops></button>

--- a/src/Mint-Y/metacity-1/metacity-theme-3.xml
+++ b/src/Mint-Y/metacity-1/metacity-theme-3.xml
@@ -112,12 +112,8 @@
 	<distance name="title_vertical_pad" value="5"/>
 </frame_geometry>
 
-<!--chromium save dialog-->
-<frame_geometry name="attached" title_scale="small" has_title="false"  hide_buttons="true" rounded_top_left="1" rounded_top_right="1" rounded_bottom_left="0" rounded_bottom_right="0" parent="normal">
-	<distance name="title_vertical_pad" value="0"/>
-	<distance name="bottom_height" value="1"/>
-	<distance name="left_width" value="1"/>
-	<distance name="right_width" value="1"/>
+<frame_geometry name="attached" title_scale="small" hide_buttons="true" rounded_top_left="1" rounded_top_right="1" parent="small">
+	<distance name="title_vertical_pad" value="5"/>
 </frame_geometry>
 
 <!-- drawing operations -->
@@ -941,6 +937,7 @@
 <frame_style name="attached_focused" geometry="attached">
 	<piece position="entire_background" draw_ops="entire_background_focused" />
 	<piece position="titlebar" draw_ops="titlebar_focused" />
+	<piece position="title" draw_ops="title_focused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
 	<button function="close" state="pressed"><draw_ops></draw_ops></button>
 	<button function="maximize" state="normal"><draw_ops></draw_ops></button>
@@ -966,6 +963,7 @@
 <frame_style name="attached_unfocused" geometry="attached">
 	<piece position="entire_background" draw_ops="entire_background_unfocused" />
 	<piece position="titlebar" draw_ops="titlebar_unfocused" />
+	<piece position="title" draw_ops="title_unfocused" />
 	<button function="close" state="normal"><draw_ops></draw_ops></button>
 	<button function="close" state="pressed"><draw_ops></draw_ops></button>
 	<button function="maximize" state="normal"><draw_ops></draw_ops></button>


### PR DESCRIPTION
Fixes ugly empty titlebar on attached dialogs when the Window Manager option `Attach dialog windows to the parent window` is enabled

Same issue affects Mint-X .... Will also make a PR for those if this is merged.

There are probably other options to fix this i.e. making attached windows use a normal_style_set as has been done with unattached dialogs and modal dialogs but this is the way most other themes do it. 

Before
![screenshot-screen-2018-12-11-173942](https://user-images.githubusercontent.com/29017677/49821316-1a0da100-fd72-11e8-959b-10d373c8081e.png)

After
![screenshot-screen-2018-12-11-180352](https://user-images.githubusercontent.com/29017677/49821339-25f96300-fd72-11e8-9f72-265bcd0c4380.png)

