### PR TITLE
Mint-themes fix expo workspace entry not expanding to fit scaled fonts

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1902,7 +1902,7 @@ StScrollBar StButton#vhandle:hover {
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
     width: 250px;
-    height: 15px;
+    height: 1.5em;
     box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.6);
     text-align: center;
 }

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1904,7 +1904,7 @@ StScrollBar StButton#vhandle:hover {
     border-image: url("misc-assets/expo-name-entry.png") 6;
     padding: 8px 12px;
     border-radius: 2px;
-    height: 15px;
+    height: 1.5em;
     color: rgba(255, 255, 255, 0.7);
     text-align: center;
     font-weight: bold;

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -619,7 +619,7 @@ StScrollBar {
 
 .expo-workspaces-name-entry,
 .expo-workspaces-name-entry#selected {
-  height: 15px;
+  height: 1.5em;
   border-radius: 2px;
   font-size: 9pt;
   padding: 5px 8px;


### PR DESCRIPTION
Fixes https://github.com/linuxmint/Cinnamon/issues/8111 - expo workspace entries cutting off text when fonts are scaled > 1.

After + Before Screenshots

![screenshot-screen-2018-12-15-080646](https://user-images.githubusercontent.com/29017677/50040717-fc299000-0040-11e9-8321-df659b79490a.png)
![screenshot-screen-2018-12-15-080610](https://user-images.githubusercontent.com/29017677/50040718-fc299000-0040-11e9-88b6-ddfc150aca17.png)
![screenshot-screen-2018-12-15-080340](https://user-images.githubusercontent.com/29017677/50040719-fcc22680-0040-11e9-9cad-1bfbe47dbd6d.png)
![screenshot-screen-2018-12-15-080320](https://user-images.githubusercontent.com/29017677/50040721-fcc22680-0040-11e9-9d41-a3577ff04d0f.png)
![screenshot-screen-2018-12-15-075903](https://user-images.githubusercontent.com/29017677/50040722-fcc22680-0040-11e9-9eb7-fa55fe801e9b.png)
![screenshot-screen-2018-12-15-075836](https://user-images.githubusercontent.com/29017677/50040723-fcc22680-0040-11e9-9bd7-6855c7ec5e7d.png)
