### PR TITLE
Mint X & Y - Keyboard applet & workspace-switcher simple fixes for vertical panels

### DIFF
--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1708,6 +1708,7 @@ StScrollBar StButton#vhandle:hover {
 
 .workspace-button.vertical {
     padding: 0px;
+    height: 1.5em;
 }
 
 .workspace-button:hover {

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -558,7 +558,6 @@ StScrollBar {
     -minimum-hpadding: 3px;
     font-weight: bold;
     color: white;
-    height: 22px;
 
     &:hover {}
   }
@@ -1770,7 +1769,7 @@ StScrollBar {
   transition-duration: 200;
 
   &.vertical {
-    height: 14px;
+    height: 1.5em;
     width: 24px;
     padding: 0;
     padding-top: 3px;


### PR DESCRIPTION
Fixes..

Mint-Y - keyboard applet icon size can exceed applet container at some panel settings on a vertical panel. This looks bad when highlighting the icon or in text mode.

Mint-Y - workspace-switcher simple buttons - not enough height to centre the text in the button on a vertical panel

Mint-X - workspace-switcher simple buttons - not enough height to show or centre the text in the button on a vertical panel.

Before

![screenshot-area-2019-01-10-194211](https://user-images.githubusercontent.com/29017677/50993386-77cc0f00-1511-11e9-8f80-7b1ed26f01a6.png)
![screenshot-area-2019-01-10-193830](https://user-images.githubusercontent.com/29017677/50993393-7bf82c80-1511-11e9-8d4f-96f550a015b5.png)

After

![screenshot-area-2019-01-10-194316](https://user-images.githubusercontent.com/29017677/50993408-85819480-1511-11e9-8fec-953c98f6b781.png)
![screenshot-area-2019-01-10-194141](https://user-images.githubusercontent.com/29017677/50993423-8e726600-1511-11e9-951d-778a9e91e83a.png)



