### PR TITLE
Mint-Y: adjust for grouped-window-list-thumbnail-menu becoming active

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -443,8 +443,7 @@ StScrollBar {
   -natural-hpadding: 3px;
   -minimum-hpadding: 3px;
   font-weight: bold;
-  color: white;
-  height: 22px; }
+  color: white; }
 .panel-button {
   -natural-hpadding: 6px;
   -minimum-hpadding: 2px;
@@ -490,7 +489,7 @@ StScrollBar {
 
 .expo-workspaces-name-entry,
 .expo-workspaces-name-entry#selected {
-  height: 15px;
+  height: 1.5em;
   border-radius: 2px;
   font-size: 9pt;
   padding: 5px 8px;
@@ -1186,7 +1185,7 @@ StScrollBar {
   border: 1px solid #202020;
   background-color: #2f2f2f;
   border-radius: 3px;
-  padding: 20px; }
+  padding: 0px; }
   .grouped-window-list-thumbnail-menu > StBoxLayout {
     padding: 4px; }
   .grouped-window-list-thumbnail-menu .item-box {
@@ -1336,7 +1335,7 @@ StScrollBar {
   padding-top: 4px;
   transition-duration: 200; }
   .workspace-button.vertical {
-    height: 14px;
+    height: 1.5em;
     width: 24px;
     padding: 0;
     padding-top: 3px;

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -443,8 +443,7 @@ StScrollBar {
   -natural-hpadding: 3px;
   -minimum-hpadding: 3px;
   font-weight: bold;
-  color: white;
-  height: 22px; }
+  color: white; }
 .panel-button {
   -natural-hpadding: 6px;
   -minimum-hpadding: 2px;
@@ -490,7 +489,7 @@ StScrollBar {
 
 .expo-workspaces-name-entry,
 .expo-workspaces-name-entry#selected {
-  height: 15px;
+  height: 1.5em;
   border-radius: 2px;
   font-size: 9pt;
   padding: 5px 8px;
@@ -1186,7 +1185,7 @@ StScrollBar {
   border: 1px solid #d9d9d9;
   background-color: #F0F0F0;
   border-radius: 3px;
-  padding: 20px; }
+  padding: 0px; }
   .grouped-window-list-thumbnail-menu > StBoxLayout {
     padding: 4px; }
   .grouped-window-list-thumbnail-menu .item-box {
@@ -1336,7 +1335,7 @@ StScrollBar {
   padding-top: 4px;
   transition-duration: 200; }
   .workspace-button.vertical {
-    height: 14px;
+    height: 1.5em;
     width: 24px;
     padding: 0;
     padding-top: 3px;

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1576,7 +1576,7 @@ StScrollBar {
     border: 1px solid $borders_color;
     background-color: $bg_color;
     border-radius: 3px;
-    padding: 20px;
+    padding: 0px;
 
     > StBoxLayout {
       padding: 4px;


### PR DESCRIPTION
The only change is to zero the padding in the GWL thumbnail menu.  The other changes showing here appear to be from the last git commit, curious. Perhaps because I am doing mint-Y and X separately ?  