### PR TITLE
gwl: Remove unnecessary padding on the thumbnail-menu class in Mint Y

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1185,8 +1185,7 @@ StScrollBar {
   color: #f0f0f0;
   border: 1px solid #202020;
   background-color: #2f2f2f;
-  border-radius: 3px;
-  padding: 20px; }
+  border-radius: 3px; }
   .grouped-window-list-thumbnail-menu > StBoxLayout {
     padding: 4px; }
   .grouped-window-list-thumbnail-menu .item-box {

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1185,8 +1185,7 @@ StScrollBar {
   color: #202020;
   border: 1px solid #d9d9d9;
   background-color: #F0F0F0;
-  border-radius: 3px;
-  padding: 20px; }
+  border-radius: 3px; }
   .grouped-window-list-thumbnail-menu > StBoxLayout {
     padding: 4px; }
   .grouped-window-list-thumbnail-menu .item-box {

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1577,7 +1577,6 @@ StScrollBar {
     border: 1px solid $borders_color;
     background-color: $bg_color;
     border-radius: 3px;
-    padding: 20px;
 
     > StBoxLayout {
       padding: 4px;


### PR DESCRIPTION
I realize #190 addresses this for the Linux Mint theme, but went ahead and fixed this for Mint Y because I can't use Cinnamon master or branches based on it otherwise. :slightly_smiling_face: 