### PR TITLE
Remove about dialog styling from the cinnamon css

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1983,45 +1983,6 @@ StScrollBar StButton#vhandle:hover {
 }
 
 /* ===================================================================
- * About Dialog (modalDialog.js)
- * ===================================================================*/
-.about-content {
-    width: 500px;
-}
-
-.about-title {
-    font-size: 1.2em;
-    font-weight: bold;
-}
-
-.about-uuid {
-    font-size: .8em;
-}
-
-.about-icon {
-    padding-right: 20px;
-}
-
-.about-scrollBox {
-    height: 100px;
-    border: solid 1px grey;
-    border-radius: 4px;
-}
-
-.about-scrollBox-innerBox {
-    padding: 0.5em;
-    spacing: 1.2em;
-}
-
-.about-description {
-    padding-top: 4px;
-    padding-bottom: 8px;
-}
-
-.about-version {
-}
-
-/* ===================================================================
  * Snap/Tile Chrome (windowManager.js)
  * ===================================================================*/
 .tile-preview,

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -2013,45 +2013,6 @@ StScrollBar StButton#vhandle:hover {
 }
 
 /* ===================================================================
- * About Dialog (modalDialog.js)
- * ===================================================================*/
-.about-content {
-    width: 500px;
-}
-
-.about-title {
-    font-size: 1.2em;
-    font-weight: bold;
-}
-
-.about-uuid {
-    font-size: .8em;
-}
-
-.about-icon {
-    padding-right: 20px;
-}
-
-.about-scrollBox {
-    height: 100px;
-    border: solid 1px grey;
-    border-radius: 4px;
-}
-
-.about-scrollBox-innerBox {
-    padding: 0.5em;
-    spacing: 1.2em;
-}
-
-.about-description {
-    padding-top: 4px;
-    padding-bottom: 8px;
-}
-
-.about-version {
-}
-
-/* ===================================================================
  * OSD Popups
  * ===================================================================*/
 .info-osd {

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -563,34 +563,6 @@ StScrollBar {
   height: 120px;
   width: 400px; }
 
-.about-content {
-  width: 550px; }
-.about-title {
-  font-size: 1.2em;
-  font-weight: bold; }
-.about-uuid {
-  font-size: 0.9em;
-  color: #888; }
-.about-icon {
-  padding-right: 12px; }
-.about-scrollBox {
-  height: 100px;
-  border: 1px solid #202020;
-  border-radius: 2px;
-  background-color: #404040;
-  padding: 4px;
-  padding-right: 0;
-  border-radius: 0; }
-  .about-scrollBox-innerBox {
-    padding: 1.2em;
-    spacing: 1.2em; }
-.about-description {
-  padding-top: 4px;
-  padding-bottom: 4px; }
-.about-version {
-  font-size: 1.0em;
-  color: #888; }
-
 .calendar {
   padding: .4em 1.75em;
   spacing-rows: 0px;

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -563,34 +563,6 @@ StScrollBar {
   height: 120px;
   width: 400px; }
 
-.about-content {
-  width: 550px; }
-.about-title {
-  font-size: 1.2em;
-  font-weight: bold; }
-.about-uuid {
-  font-size: 0.9em;
-  color: #888; }
-.about-icon {
-  padding-right: 12px; }
-.about-scrollBox {
-  height: 100px;
-  border: 1px solid #d9d9d9;
-  border-radius: 2px;
-  background-color: #ffffff;
-  padding: 4px;
-  padding-right: 0;
-  border-radius: 0; }
-  .about-scrollBox-innerBox {
-    padding: 1.2em;
-    spacing: 1.2em; }
-.about-description {
-  padding-top: 4px;
-  padding-bottom: 4px; }
-.about-version {
-  font-size: 1.0em;
-  color: #888; }
-
 .calendar {
   padding: .4em 1.75em;
   spacing-rows: 0px;


### PR DESCRIPTION
Due to https://github.com/linuxmint/cinnamon/pull/8734 it is no longer needed.
*Note: this should not be merged until the above pull request is merged