### PR TITLE
Mint-Y: Update the theme for newer libsass

### DIFF
--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -66,8 +66,7 @@ flowbox flowboxchild {
   flowbox flowboxchild:selected {
     outline-offset: -2px; }
 
-label.separator, popover label.separator,
-popover.background label.separator {
+label.separator {
   color: #DADADA; }
 
 label selection {
@@ -256,15 +255,15 @@ button {
   background-color: #454545; }
   button separator {
     margin: 4px 1px; }
-  button.flat, button.sidebar-button {
+  button.sidebar-button, button.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     transition: none; }
-    button.flat:hover, button.sidebar-button:hover {
+    button.sidebar-button:hover, button.flat:hover {
       transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
       transition-duration: 350ms; }
-      button.flat:hover:active, button.sidebar-button:hover:active {
+      button.sidebar-button:hover:active, button.flat:hover:active {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #DADADA;
@@ -286,7 +285,7 @@ button {
     color: #DADADA; }
   button:active:hover, button:checked {
     color: #ffffff; }
-  button.flat:disabled, button.sidebar-button:disabled {
+  button.sidebar-button, button.flat:disabled {
     border-color: transparent;
     background-color: transparent;
     background-image: none; }
@@ -328,7 +327,7 @@ button {
     .titlebar button.text-button.popup.titlebutton {
       padding-right: 8px;
       padding-left: 8px; }
-  button:drop(active), combobox:drop(active) button.combo {
+  combobox:drop(active) button.combo, button:drop(active) {
     color: #8fa876;
     border-color: #8fa876;
     box-shadow: none; }
@@ -373,22 +372,22 @@ button {
       color: #676767;
       border-color: rgba(22, 22, 22, 0.4);
       background-color: rgba(109, 109, 109, 0.25); }
-    .osd button.flat, .osd button.sidebar-button {
+    .osd button.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
       box-shadow: none; }
-      .osd button.flat:hover, .osd button.sidebar-button:hover {
+      .osd button.flat:hover {
         color: #dbdbdb;
         outline-color: rgba(219, 219, 219, 0.3);
         border-color: rgba(22, 22, 22, 0.4);
         background-color: rgba(127, 127, 127, 0.5); }
-      .osd button.flat:disabled, .osd button.sidebar-button:disabled {
+      .osd button.flat:disabled {
         color: #676767;
         border-color: rgba(22, 22, 22, 0.4);
         background-color: rgba(109, 109, 109, 0.25);
         background-image: none; }
-      .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
+      .osd button.flat:active, .osd button.flat:checked {
         color: #ffffff;
         outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(22, 22, 22, 0.4);
@@ -402,7 +401,7 @@ button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #6db442;
     border-color: #6db442; }
-    button.suggested-action.flat, button.suggested-action.sidebar-button {
+    button.suggested-action.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -420,7 +419,7 @@ button {
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: #568f34;
       border-color: #568f34; }
-    button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
+    button.suggested-action.flat:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -437,7 +436,7 @@ button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #F04A50;
     border-color: #F04A50; }
-    button.destructive-action.flat, button.destructive-action.sidebar-button {
+    button.destructive-action.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -455,7 +454,7 @@ button {
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: #ec1b22;
       border-color: #ec1b22; }
-    button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
+    button.destructive-action.flat:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -529,7 +528,7 @@ button {
     .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
       color: inherit; }
 
-toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
+toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, .linked:not(.vertical) > entry,
 .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button,
 .linked:not(.vertical) > button:hover,
 .linked:not(.vertical) > button:active,
@@ -553,7 +552,7 @@ headerbar .linked:not(.vertical).path-bar > button:disabled, .primary-toolbar to
   border-radius: 0;
   border-right-style: none; }
 
-.linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, toolbar.inline-toolbar toolbutton:first-child > button.sidebar-button, .inline-toolbar toolbutton:first-child > button.sidebar-button, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > combobox:first-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
+toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
@@ -561,11 +560,13 @@ headerbar .linked:not(.vertical).path-bar > button:first-child,
 headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:first-child:active,
 headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled, .linked:not(.vertical) > combobox:first-child > box > button.combo {
   border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px; }
+  border-bottom-left-radius: 3px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
 
-.linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, toolbar.inline-toolbar toolbutton:last-child > button.sidebar-button, .inline-toolbar toolbutton:last-child > button.sidebar-button, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > combobox:last-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
+toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
@@ -573,12 +574,14 @@ headerbar .linked:not(.vertical).path-bar > button:last-child,
 headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:last-child:active,
 headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox:last-child > box > button.combo {
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
   border-right-style: solid; }
 
-.linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, toolbar.inline-toolbar toolbutton:only-child > button.sidebar-button, .inline-toolbar toolbutton:only-child > button.sidebar-button, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > combobox:only-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
+toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
@@ -586,7 +589,7 @@ headerbar .linked:not(.vertical).path-bar > button:only-child,
 headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:only-child:active,
 headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled, .linked:not(.vertical) > combobox:only-child > box > button.combo {
   border-radius: 3px;
   border-style: solid; }
 
@@ -612,7 +615,7 @@ headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, .app-notification button.flat, .app-notification button.flat:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -649,25 +652,34 @@ modelbutton.flat arrow.left {
 modelbutton.flat arrow.right {
   -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
 
-*:link, button:link, button:visited {
+button:link, button:visited,
+*:link {
   color: #5294E2; }
-  *:link:visited, button:visited {
+  button:visited,
+  *:link:visited {
     color: #5294E2; }
-    *:selected *:link:visited, *:selected button:visited:link, *:selected button:visited {
+    *:selected button:visited, *:selected
+    *:link:visited {
       color: #d2dcc8; }
-  *:link:hover, button:hover:link, button:hover:visited {
+  button:hover:link, button:hover:visited,
+  *:link:hover {
     color: #7eafe9; }
-    *:selected *:link:hover, *:selected button:hover:link, *:selected button:hover:visited {
+    *:selected button:hover:link, *:selected button:hover:visited, *:selected
+    *:link:hover {
       color: #f4f6f1; }
-  *:link:active, button:active:link, button:active:visited {
+  button:active:link, button:active:visited,
+  *:link:active {
     color: #5294E2; }
-    *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
+    *:selected button:active:link, *:selected button:active:visited, *:selected
+    *:link:active {
       color: #e9eee4; }
-  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link,
-  .selection-mode.titlebar:not(headerbar) .subtitle:link,
-  *:selected *:link,
+  headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, button:selected:link, button:selected:visited,
   *:selected button:link,
-  *:selected button:visited {
+  *:selected button:visited,
+  *:link:selected,
+  *:selected
+  *:link {
     color: #e9eee4; }
 
 button:link > label, button:visited > label {
@@ -863,9 +875,8 @@ headerbar,
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: rgba(255, 255, 255, 0);
       border-color: rgba(255, 255, 255, 0); }
-      headerbar.selection-mode button.flat, headerbar.selection-mode button.sidebar-button,
-      .selection-mode.titlebar:not(headerbar) button.flat,
-      .selection-mode.titlebar:not(headerbar) button.sidebar-button {
+      headerbar.selection-mode button.flat,
+      .selection-mode.titlebar:not(headerbar) button.flat {
         border-color: transparent;
         background-color: transparent;
         background-image: none;
@@ -1052,7 +1063,7 @@ window.csd > .titlebar:not(headerbar):backdrop {
     border-color: rgba(143, 168, 118, 0.65);
     background-color: rgba(143, 168, 118, 0.65); }
 
-.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat, .primary-toolbar toolbar.selection-mode button.sidebar-button, .primary-toolbar .selection-mode.inline-toolbar button.sidebar-button, .selection-mode.primary-toolbar button.sidebar-button, headerbar.selection-mode button.sidebar-button {
+.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -1155,7 +1166,7 @@ headerbar .linked:not(.vertical).path-bar > button {
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #6db442;
   border-color: #6db442; }
-  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar toolbar button.suggested-action.sidebar-button, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
+  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
@@ -1173,11 +1184,11 @@ headerbar .linked:not(.vertical).path-bar > button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #568f34;
     border-color: #568f34; }
-  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action.sidebar-button:disabled, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar button.suggested-action.sidebar-button:disabled label, headerbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
       color: inherit; }
 
 .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop, .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
@@ -1189,7 +1200,7 @@ headerbar .linked:not(.vertical).path-bar > button {
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #F04A50;
   border-color: #F04A50; }
-  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar toolbar button.destructive-action.sidebar-button, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
+  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
@@ -1207,11 +1218,11 @@ headerbar .linked:not(.vertical).path-bar > button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #ec1b22;
     border-color: #ec1b22; }
-  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action.sidebar-button:disabled, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar button.destructive-action.sidebar-button:disabled label, headerbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
       color: inherit; }
 
 .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop, .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
@@ -1545,6 +1556,9 @@ popover.background {
   popover separator,
   popover.background separator {
     background-color: #383838; }
+  popover label.separator,
+  popover.background label.separator {
+    color: #DADADA; }
   popover > list,
   popover > .view,
   popover > iconview,
@@ -1693,16 +1707,16 @@ notebook {
         color: #DADADA;
         background-color: #404040;
         border-color: #292929; }
-      notebook > header > tabs > tab button.flat, notebook > header > tabs > tab button.sidebar-button {
+      notebook > header > tabs > tab button.flat {
         min-height: 22px;
         min-width: 16px;
         padding: 0;
         color: #a1a1a1; }
-        notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover {
+        notebook > header > tabs > tab button.flat:hover {
           color: #ff4d4d; }
-        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover {
+        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #8fa876; }
-    notebook > header button.flat, notebook > header button.sidebar-button {
+    notebook > header button.flat {
       padding: 2px; }
 
 scrollbar {
@@ -2410,7 +2424,7 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     outline-color: rgba(219, 219, 219, 0.3);
     border-color: rgba(22, 22, 22, 0.4);
     background-color: rgba(109, 109, 109, 0.4); }
-    .app-notification button.flat, .app-notification button.sidebar-button {
+    .app-notification button.flat {
       border-color: rgba(143, 168, 118, 0); }
     .app-notification button:hover {
       color: #dbdbdb;
@@ -2660,13 +2674,13 @@ infobar {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button {
+row:selected button.flat, infobar.info button.flat, infobar.question button.flat, infobar.warning button.flat, infobar.error button.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label {
+  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
 row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
@@ -2674,7 +2688,7 @@ row:selected button:hover, infobar.info button:hover, infobar.question button:ho
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .primary-toolbar toolbar.selection-mode button:hover:active, .primary-toolbar .selection-mode.inline-toolbar button:hover:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .primary-toolbar toolbar.selection-mode button:hover:checked, .primary-toolbar .selection-mode.inline-toolbar button:hover:checked, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
   color: #8fa876;
   background-color: #ffffff;
   border-color: #ffffff; }
@@ -2684,7 +2698,7 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
   border-color: rgba(255, 255, 255, 0.4); }
   row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+  .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
     color: #8fa876;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2973,10 +2987,10 @@ filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-windo
   filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
   filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
     color: #ffffff; }
-    row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
+    label:disabled selection, row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text:disabled:selected:focus,
     textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
-    textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    textview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
@@ -3072,12 +3086,15 @@ vte-terminal {
 .nautilus-canvas-item {
   border-radius: 2px; }
 
-.nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nemo-desktop.nemo-canvas-item,
+.nautilus-desktop.nautilus-canvas-item {
   color: #ffffff;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
-  .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active {
+  .nemo-desktop.nemo-canvas-item:active,
+  .nautilus-desktop.nautilus-canvas-item:active {
     color: #DADADA; }
-  .nautilus-desktop.nautilus-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+  .nemo-desktop.nemo-canvas-item:selected,
+  .nautilus-desktop.nautilus-canvas-item:selected {
     color: #ffffff; }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
@@ -3910,13 +3927,13 @@ filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollba
 window.background.lightdm menubar > menuitem {
   padding: 0 5px 0 5px; }
 
-window.background.lightdm button.flat.option-button, window.background.lightdm button.option-button.sidebar-button {
+window.background.lightdm button.flat.option-button {
   background-color: transparent;
   color: #dadada; }
-  window.background.lightdm button.flat.option-button:hover, window.background.lightdm button.option-button.sidebar-button:hover {
+  window.background.lightdm button.flat.option-button:hover {
     border-color: rgba(41, 41, 41, 0.2);
     background-color: rgba(0, 0, 0, 0.5); }
-  window.background.lightdm button.flat.option-button:active, window.background.lightdm button.option-button.sidebar-button:active {
+  window.background.lightdm button.flat.option-button:active {
     border-color: #292929;
     background-color: #8fa876;
     color: #ffffff; }

--- a/src/Mint-Y/gtk-3.0/gtk-darker.css
+++ b/src/Mint-Y/gtk-3.0/gtk-darker.css
@@ -66,8 +66,7 @@ flowbox flowboxchild {
   flowbox flowboxchild:selected {
     outline-offset: -2px; }
 
-label.separator, popover label.separator,
-popover.background label.separator {
+label.separator {
   color: #303030; }
 
 label selection {
@@ -255,15 +254,15 @@ button {
   background-color: whitesmoke; }
   button separator {
     margin: 4px 1px; }
-  button.flat, button.sidebar-button {
+  button.sidebar-button, button.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     transition: none; }
-    button.flat:hover, button.sidebar-button:hover {
+    button.sidebar-button:hover, button.flat:hover {
       transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
       transition-duration: 350ms; }
-      button.flat:hover:active, button.sidebar-button:hover:active {
+      button.sidebar-button:hover:active, button.flat:hover:active {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #303030;
@@ -285,7 +284,7 @@ button {
     color: #303030; }
   button:active:hover, button:checked {
     color: #ffffff; }
-  button.flat:disabled, button.sidebar-button:disabled {
+  button.sidebar-button, button.flat:disabled {
     border-color: transparent;
     background-color: transparent;
     background-image: none; }
@@ -327,7 +326,7 @@ button {
     .titlebar button.text-button.popup.titlebutton {
       padding-right: 8px;
       padding-left: 8px; }
-  button:drop(active), combobox:drop(active) button.combo {
+  combobox:drop(active) button.combo, button:drop(active) {
     color: #92b372;
     border-color: #92b372;
     box-shadow: none; }
@@ -372,22 +371,22 @@ button {
       color: #6f6f6f;
       border-color: rgba(33, 33, 33, 0.4);
       background-color: rgba(120, 120, 120, 0.25); }
-    .osd button.flat, .osd button.sidebar-button {
+    .osd button.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
       box-shadow: none; }
-      .osd button.flat:hover, .osd button.sidebar-button:hover {
+      .osd button.flat:hover {
         color: #dbdbdb;
         outline-color: rgba(219, 219, 219, 0.3);
         border-color: rgba(33, 33, 33, 0.4);
         background-color: rgba(138, 138, 138, 0.5); }
-      .osd button.flat:disabled, .osd button.sidebar-button:disabled {
+      .osd button.flat:disabled {
         color: #6f6f6f;
         border-color: rgba(33, 33, 33, 0.4);
         background-color: rgba(120, 120, 120, 0.25);
         background-image: none; }
-      .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
+      .osd button.flat:active, .osd button.flat:checked {
         color: #ffffff;
         outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(33, 33, 33, 0.4);
@@ -401,7 +400,7 @@ button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #6db442;
     border-color: #6db442; }
-    button.suggested-action.flat, button.suggested-action.sidebar-button {
+    button.suggested-action.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -419,7 +418,7 @@ button {
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: #568f34;
       border-color: #568f34; }
-    button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
+    button.suggested-action.flat:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -436,7 +435,7 @@ button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #F04A50;
     border-color: #F04A50; }
-    button.destructive-action.flat, button.destructive-action.sidebar-button {
+    button.destructive-action.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -454,7 +453,7 @@ button {
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: #ec1b22;
       border-color: #ec1b22; }
-    button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
+    button.destructive-action.flat:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -528,7 +527,7 @@ button {
     .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
       color: inherit; }
 
-toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
+toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, .linked:not(.vertical) > entry,
 .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button,
 .linked:not(.vertical) > button:hover,
 .linked:not(.vertical) > button:active,
@@ -552,7 +551,7 @@ headerbar .linked:not(.vertical).path-bar > button:disabled, .primary-toolbar to
   border-radius: 0;
   border-right-style: none; }
 
-.linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, toolbar.inline-toolbar toolbutton:first-child > button.sidebar-button, .inline-toolbar toolbutton:first-child > button.sidebar-button, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > combobox:first-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
+toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
@@ -560,11 +559,13 @@ headerbar .linked:not(.vertical).path-bar > button:first-child,
 headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:first-child:active,
 headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled, .linked:not(.vertical) > combobox:first-child > box > button.combo {
   border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px; }
+  border-bottom-left-radius: 3px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
 
-.linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, toolbar.inline-toolbar toolbutton:last-child > button.sidebar-button, .inline-toolbar toolbutton:last-child > button.sidebar-button, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > combobox:last-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
+toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
@@ -572,12 +573,14 @@ headerbar .linked:not(.vertical).path-bar > button:last-child,
 headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:last-child:active,
 headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox:last-child > box > button.combo {
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
   border-right-style: solid; }
 
-.linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, toolbar.inline-toolbar toolbutton:only-child > button.sidebar-button, .inline-toolbar toolbutton:only-child > button.sidebar-button, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > combobox:only-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
+toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
@@ -585,7 +588,7 @@ headerbar .linked:not(.vertical).path-bar > button:only-child,
 headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:only-child:active,
 headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled, .linked:not(.vertical) > combobox:only-child > box > button.combo {
   border-radius: 3px;
   border-style: solid; }
 
@@ -611,7 +614,7 @@ headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, .app-notification button.flat, .app-notification button.flat:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -648,25 +651,34 @@ modelbutton.flat arrow.left {
 modelbutton.flat arrow.right {
   -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
 
-*:link, button:link, button:visited {
+button:link, button:visited,
+*:link {
   color: #5294E2; }
-  *:link:visited, button:visited {
+  button:visited,
+  *:link:visited {
     color: #5294E2; }
-    *:selected *:link:visited, *:selected button:visited:link, *:selected button:visited {
+    *:selected button:visited, *:selected
+    *:link:visited {
       color: #d3e1c7; }
-  *:link:hover, button:hover:link, button:hover:visited {
+  button:hover:link, button:hover:visited,
+  *:link:hover {
     color: #7eafe9; }
-    *:selected *:link:hover, *:selected button:hover:link, *:selected button:hover:visited {
+    *:selected button:hover:link, *:selected button:hover:visited, *:selected
+    *:link:hover {
       color: #f4f7f1; }
-  *:link:active, button:active:link, button:active:visited {
+  button:active:link, button:active:visited,
+  *:link:active {
     color: #5294E2; }
-    *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
+    *:selected button:active:link, *:selected button:active:visited, *:selected
+    *:link:active {
       color: #e9f0e3; }
-  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link,
-  .selection-mode.titlebar:not(headerbar) .subtitle:link,
-  *:selected *:link,
+  headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, button:selected:link, button:selected:visited,
   *:selected button:link,
-  *:selected button:visited {
+  *:selected button:visited,
+  *:link:selected,
+  *:selected
+  *:link {
     color: #e9f0e3; }
 
 button:link > label, button:visited > label {
@@ -862,9 +874,8 @@ headerbar,
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: rgba(255, 255, 255, 0);
       border-color: rgba(255, 255, 255, 0); }
-      headerbar.selection-mode button.flat, headerbar.selection-mode button.sidebar-button,
-      .selection-mode.titlebar:not(headerbar) button.flat,
-      .selection-mode.titlebar:not(headerbar) button.sidebar-button {
+      headerbar.selection-mode button.flat,
+      .selection-mode.titlebar:not(headerbar) button.flat {
         border-color: transparent;
         background-color: transparent;
         background-image: none;
@@ -1051,7 +1062,7 @@ window.csd > .titlebar:not(headerbar):backdrop {
     border-color: rgba(146, 179, 114, 0.65);
     background-color: rgba(146, 179, 114, 0.65); }
 
-.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat, .primary-toolbar toolbar.selection-mode button.sidebar-button, .primary-toolbar .selection-mode.inline-toolbar button.sidebar-button, .selection-mode.primary-toolbar button.sidebar-button, headerbar.selection-mode button.sidebar-button {
+.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -1154,7 +1165,7 @@ headerbar .linked:not(.vertical).path-bar > button {
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #6db442;
   border-color: #6db442; }
-  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar toolbar button.suggested-action.sidebar-button, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
+  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
@@ -1172,11 +1183,11 @@ headerbar .linked:not(.vertical).path-bar > button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #568f34;
     border-color: #568f34; }
-  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action.sidebar-button:disabled, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar button.suggested-action.sidebar-button:disabled label, headerbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
       color: inherit; }
 
 .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop, .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
@@ -1188,7 +1199,7 @@ headerbar .linked:not(.vertical).path-bar > button {
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #F04A50;
   border-color: #F04A50; }
-  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar toolbar button.destructive-action.sidebar-button, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
+  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
@@ -1206,11 +1217,11 @@ headerbar .linked:not(.vertical).path-bar > button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #ec1b22;
     border-color: #ec1b22; }
-  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action.sidebar-button:disabled, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar button.destructive-action.sidebar-button:disabled label, headerbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
       color: inherit; }
 
 .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop, .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
@@ -1544,6 +1555,9 @@ popover.background {
   popover separator,
   popover.background separator {
     background-color: #ffffff; }
+  popover label.separator,
+  popover.background label.separator {
+    color: #303030; }
   popover > list,
   popover > .view,
   popover > iconview,
@@ -1692,16 +1706,16 @@ notebook {
         color: #303030;
         background-color: #ffffff;
         border-color: #BDBDBD; }
-      notebook > header > tabs > tab button.flat, notebook > header > tabs > tab button.sidebar-button {
+      notebook > header > tabs > tab button.flat {
         min-height: 22px;
         min-width: 16px;
         padding: 0;
         color: #737373; }
-        notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover {
+        notebook > header > tabs > tab button.flat:hover {
           color: #ff4d4d; }
-        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover {
+        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #92b372; }
-    notebook > header button.flat, notebook > header button.sidebar-button {
+    notebook > header button.flat {
       padding: 2px; }
 
 scrollbar {
@@ -2409,7 +2423,7 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     outline-color: rgba(219, 219, 219, 0.3);
     border-color: rgba(33, 33, 33, 0.4);
     background-color: rgba(120, 120, 120, 0.4); }
-    .app-notification button.flat, .app-notification button.sidebar-button {
+    .app-notification button.flat {
       border-color: rgba(146, 179, 114, 0); }
     .app-notification button:hover {
       color: #dbdbdb;
@@ -2659,13 +2673,13 @@ infobar {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button {
+row:selected button.flat, infobar.info button.flat, infobar.question button.flat, infobar.warning button.flat, infobar.error button.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label {
+  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
 row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
@@ -2673,7 +2687,7 @@ row:selected button:hover, infobar.info button:hover, infobar.question button:ho
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .primary-toolbar toolbar.selection-mode button:hover:active, .primary-toolbar .selection-mode.inline-toolbar button:hover:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .primary-toolbar toolbar.selection-mode button:hover:checked, .primary-toolbar .selection-mode.inline-toolbar button:hover:checked, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
   color: #92b372;
   background-color: #ffffff;
   border-color: #ffffff; }
@@ -2683,7 +2697,7 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
   border-color: rgba(255, 255, 255, 0.4); }
   row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+  .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
     color: #92b372;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2972,10 +2986,10 @@ filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-windo
   filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
   filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
     color: #ffffff; }
-    row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
+    label:disabled selection, row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text:disabled:selected:focus,
     textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
-    textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    textview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
@@ -3071,12 +3085,15 @@ vte-terminal {
 .nautilus-canvas-item {
   border-radius: 2px; }
 
-.nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nemo-desktop.nemo-canvas-item,
+.nautilus-desktop.nautilus-canvas-item {
   color: #ffffff;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
-  .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active {
+  .nemo-desktop.nemo-canvas-item:active,
+  .nautilus-desktop.nautilus-canvas-item:active {
     color: #303030; }
-  .nautilus-desktop.nautilus-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+  .nemo-desktop.nemo-canvas-item:selected,
+  .nautilus-desktop.nautilus-canvas-item:selected {
     color: #ffffff; }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
@@ -3913,13 +3930,13 @@ filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollba
 window.background.lightdm menubar > menuitem {
   padding: 0 5px 0 5px; }
 
-window.background.lightdm button.flat.option-button, window.background.lightdm button.option-button.sidebar-button {
+window.background.lightdm button.flat.option-button {
   background-color: transparent;
   color: #dadada; }
-  window.background.lightdm button.flat.option-button:hover, window.background.lightdm button.option-button.sidebar-button:hover {
+  window.background.lightdm button.flat.option-button:hover {
     border-color: rgba(189, 189, 189, 0.2);
     background-color: rgba(0, 0, 0, 0.5); }
-  window.background.lightdm button.flat.option-button:active, window.background.lightdm button.option-button.sidebar-button:active {
+  window.background.lightdm button.flat.option-button:active {
     border-color: #BDBDBD;
     background-color: #92b372;
     color: #ffffff; }

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -66,8 +66,7 @@ flowbox flowboxchild {
   flowbox flowboxchild:selected {
     outline-offset: -2px; }
 
-label.separator, popover label.separator,
-popover.background label.separator {
+label.separator {
   color: #303030; }
 
 label selection {
@@ -255,15 +254,15 @@ button {
   background-color: whitesmoke; }
   button separator {
     margin: 4px 1px; }
-  button.flat, button.sidebar-button {
+  button.sidebar-button, button.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     transition: none; }
-    button.flat:hover, button.sidebar-button:hover {
+    button.sidebar-button:hover, button.flat:hover {
       transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
       transition-duration: 350ms; }
-      button.flat:hover:active, button.sidebar-button:hover:active {
+      button.sidebar-button:hover:active, button.flat:hover:active {
         transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   button:hover {
     color: #303030;
@@ -285,7 +284,7 @@ button {
     color: #303030; }
   button:active:hover, button:checked {
     color: #ffffff; }
-  button.flat:disabled, button.sidebar-button:disabled {
+  button.sidebar-button, button.flat:disabled {
     border-color: transparent;
     background-color: transparent;
     background-image: none; }
@@ -327,7 +326,7 @@ button {
     .titlebar button.text-button.popup.titlebutton {
       padding-right: 8px;
       padding-left: 8px; }
-  button:drop(active), combobox:drop(active) button.combo {
+  combobox:drop(active) button.combo, button:drop(active) {
     color: #92b372;
     border-color: #92b372;
     box-shadow: none; }
@@ -372,22 +371,22 @@ button {
       color: #6f6f6f;
       border-color: rgba(33, 33, 33, 0.4);
       background-color: rgba(120, 120, 120, 0.25); }
-    .osd button.flat, .osd button.sidebar-button {
+    .osd button.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
       box-shadow: none; }
-      .osd button.flat:hover, .osd button.sidebar-button:hover {
+      .osd button.flat:hover {
         color: #dbdbdb;
         outline-color: rgba(219, 219, 219, 0.3);
         border-color: rgba(33, 33, 33, 0.4);
         background-color: rgba(138, 138, 138, 0.5); }
-      .osd button.flat:disabled, .osd button.sidebar-button:disabled {
+      .osd button.flat:disabled {
         color: #6f6f6f;
         border-color: rgba(33, 33, 33, 0.4);
         background-color: rgba(120, 120, 120, 0.25);
         background-image: none; }
-      .osd button.flat:active, .osd button.sidebar-button:active, .osd button.flat:checked, .osd button.sidebar-button:checked {
+      .osd button.flat:active, .osd button.flat:checked {
         color: #ffffff;
         outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(33, 33, 33, 0.4);
@@ -401,7 +400,7 @@ button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #6db442;
     border-color: #6db442; }
-    button.suggested-action.flat, button.suggested-action.sidebar-button {
+    button.suggested-action.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -419,7 +418,7 @@ button {
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: #568f34;
       border-color: #568f34; }
-    button.suggested-action.flat:disabled, button.suggested-action.sidebar-button:disabled {
+    button.suggested-action.flat:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -436,7 +435,7 @@ button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #F04A50;
     border-color: #F04A50; }
-    button.destructive-action.flat, button.destructive-action.sidebar-button {
+    button.destructive-action.flat {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -454,7 +453,7 @@ button {
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: #ec1b22;
       border-color: #ec1b22; }
-    button.destructive-action.flat:disabled, button.destructive-action.sidebar-button:disabled {
+    button.destructive-action.flat:disabled {
       border-color: transparent;
       background-color: transparent;
       background-image: none;
@@ -528,7 +527,7 @@ button {
     .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
       color: inherit; }
 
-toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, toolbar.inline-toolbar toolbutton > button.sidebar-button, .inline-toolbar toolbutton > button.sidebar-button, .linked:not(.vertical) > entry,
+toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, .linked:not(.vertical) > entry,
 .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button,
 .linked:not(.vertical) > button:hover,
 .linked:not(.vertical) > button:active,
@@ -552,7 +551,7 @@ headerbar .linked:not(.vertical).path-bar > button:disabled, .primary-toolbar to
   border-radius: 0;
   border-right-style: none; }
 
-.linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, toolbar.inline-toolbar toolbutton:first-child > button.sidebar-button, .inline-toolbar toolbutton:first-child > button.sidebar-button, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > combobox:first-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
+toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
@@ -560,11 +559,13 @@ headerbar .linked:not(.vertical).path-bar > button:first-child,
 headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:first-child:active,
 headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled, .linked:not(.vertical) > combobox:first-child > box > button.combo {
   border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px; }
+  border-bottom-left-radius: 3px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
 
-.linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, toolbar.inline-toolbar toolbutton:last-child > button.sidebar-button, .inline-toolbar toolbutton:last-child > button.sidebar-button, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > combobox:last-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
+toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
@@ -572,12 +573,14 @@ headerbar .linked:not(.vertical).path-bar > button:last-child,
 headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:last-child:active,
 headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox:last-child > box > button.combo {
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
   border-right-style: solid; }
 
-.linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, toolbar.inline-toolbar toolbutton:only-child > button.sidebar-button, .inline-toolbar toolbutton:only-child > button.sidebar-button, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > combobox:only-child > box > button.combo, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
+toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
 .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
 .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
 .primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
@@ -585,7 +588,7 @@ headerbar .linked:not(.vertical).path-bar > button:only-child,
 headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
 headerbar .linked:not(.vertical).path-bar > button:only-child:active,
 headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled {
+headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled, .linked:not(.vertical) > combobox:only-child > box > button.combo {
   border-radius: 3px;
   border-style: solid; }
 
@@ -611,7 +614,7 @@ headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary
   border-style: solid; }
 
 menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover, .app-notification button.flat, .app-notification button.sidebar-button, .app-notification button.flat:disabled, .app-notification button.sidebar-button:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, .app-notification button.flat, .app-notification button.flat:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -648,25 +651,34 @@ modelbutton.flat arrow.left {
 modelbutton.flat arrow.right {
   -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
 
-*:link, button:link, button:visited {
+button:link, button:visited,
+*:link {
   color: #5294E2; }
-  *:link:visited, button:visited {
+  button:visited,
+  *:link:visited {
     color: #5294E2; }
-    *:selected *:link:visited, *:selected button:visited:link, *:selected button:visited {
+    *:selected button:visited, *:selected
+    *:link:visited {
       color: #d3e1c7; }
-  *:link:hover, button:hover:link, button:hover:visited {
+  button:hover:link, button:hover:visited,
+  *:link:hover {
     color: #7eafe9; }
-    *:selected *:link:hover, *:selected button:hover:link, *:selected button:hover:visited {
+    *:selected button:hover:link, *:selected button:hover:visited, *:selected
+    *:link:hover {
       color: #f4f7f1; }
-  *:link:active, button:active:link, button:active:visited {
+  button:active:link, button:active:visited,
+  *:link:active {
     color: #5294E2; }
-    *:selected *:link:active, *:selected button:active:link, *:selected button:active:visited {
+    *:selected button:active:link, *:selected button:active:visited, *:selected
+    *:link:active {
       color: #e9f0e3; }
-  infobar.info *:link, infobar.info button:link, infobar.info button:visited, infobar.question *:link, infobar.question button:link, infobar.question button:visited, infobar.warning *:link, infobar.warning button:link, infobar.warning button:visited, infobar.error *:link, infobar.error button:link, infobar.error button:visited, *:link:selected, button:selected:link, button:selected:visited, headerbar.selection-mode .subtitle:link,
-  .selection-mode.titlebar:not(headerbar) .subtitle:link,
-  *:selected *:link,
+  headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, button:selected:link, button:selected:visited,
   *:selected button:link,
-  *:selected button:visited {
+  *:selected button:visited,
+  *:link:selected,
+  *:selected
+  *:link {
     color: #e9f0e3; }
 
 button:link > label, button:visited > label {
@@ -862,9 +874,8 @@ headerbar,
       outline-color: rgba(255, 255, 255, 0.3);
       background-color: rgba(255, 255, 255, 0);
       border-color: rgba(255, 255, 255, 0); }
-      headerbar.selection-mode button.flat, headerbar.selection-mode button.sidebar-button,
-      .selection-mode.titlebar:not(headerbar) button.flat,
-      .selection-mode.titlebar:not(headerbar) button.sidebar-button {
+      headerbar.selection-mode button.flat,
+      .selection-mode.titlebar:not(headerbar) button.flat {
         border-color: transparent;
         background-color: transparent;
         background-image: none;
@@ -1051,7 +1062,7 @@ window.csd > .titlebar:not(headerbar):backdrop {
     border-color: rgba(146, 179, 114, 0.65);
     background-color: rgba(146, 179, 114, 0.65); }
 
-.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat, .primary-toolbar toolbar.selection-mode button.sidebar-button, .primary-toolbar .selection-mode.inline-toolbar button.sidebar-button, .selection-mode.primary-toolbar button.sidebar-button, headerbar.selection-mode button.sidebar-button {
+.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -1154,7 +1165,7 @@ headerbar .linked:not(.vertical).path-bar > button {
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #6db442;
   border-color: #6db442; }
-  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat, .primary-toolbar toolbar button.suggested-action.sidebar-button, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button, .primary-toolbar button.suggested-action.sidebar-button, headerbar button.suggested-action.sidebar-button {
+  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
@@ -1172,11 +1183,11 @@ headerbar .linked:not(.vertical).path-bar > button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #568f34;
     border-color: #568f34; }
-  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action.sidebar-button:disabled, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button:disabled, .primary-toolbar button.suggested-action.sidebar-button:disabled, headerbar button.suggested-action.sidebar-button:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(217, 217, 217, 0);
     border-color: rgba(217, 217, 217, 0); }
-    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar button.suggested-action.sidebar-button:disabled label, headerbar button.suggested-action.sidebar-button:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
       color: inherit; }
 
 .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop, .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
@@ -1188,7 +1199,7 @@ headerbar .linked:not(.vertical).path-bar > button {
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #F04A50;
   border-color: #F04A50; }
-  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat, .primary-toolbar toolbar button.destructive-action.sidebar-button, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button, .primary-toolbar button.destructive-action.sidebar-button, headerbar button.destructive-action.sidebar-button {
+  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
@@ -1206,11 +1217,11 @@ headerbar .linked:not(.vertical).path-bar > button {
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #ec1b22;
     border-color: #ec1b22; }
-  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action.sidebar-button:disabled, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button:disabled, .primary-toolbar button.destructive-action.sidebar-button:disabled, headerbar button.destructive-action.sidebar-button:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(217, 217, 217, 0);
     border-color: rgba(217, 217, 217, 0); }
-    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar button.destructive-action.sidebar-button:disabled label, headerbar button.destructive-action.sidebar-button:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
       color: inherit; }
 
 .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop, .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
@@ -1548,6 +1559,9 @@ popover.background {
   popover separator,
   popover.background separator {
     background-color: #ffffff; }
+  popover label.separator,
+  popover.background label.separator {
+    color: #303030; }
   popover > list,
   popover > .view,
   popover > iconview,
@@ -1696,16 +1710,16 @@ notebook {
         color: #303030;
         background-color: #ffffff;
         border-color: #BDBDBD; }
-      notebook > header > tabs > tab button.flat, notebook > header > tabs > tab button.sidebar-button {
+      notebook > header > tabs > tab button.flat {
         min-height: 22px;
         min-width: 16px;
         padding: 0;
         color: #737373; }
-        notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.sidebar-button:hover {
+        notebook > header > tabs > tab button.flat:hover {
           color: #ff4d4d; }
-        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.sidebar-button:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.sidebar-button:active:hover {
+        notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover {
           color: #92b372; }
-    notebook > header button.flat, notebook > header button.sidebar-button {
+    notebook > header button.flat {
       padding: 2px; }
 
 scrollbar {
@@ -2413,7 +2427,7 @@ row.activatable:selected.has-open-popup, row.activatable:selected:hover {
     outline-color: rgba(219, 219, 219, 0.3);
     border-color: rgba(33, 33, 33, 0.4);
     background-color: rgba(120, 120, 120, 0.4); }
-    .app-notification button.flat, .app-notification button.sidebar-button {
+    .app-notification button.flat {
       border-color: rgba(146, 179, 114, 0); }
     .app-notification button:hover {
       color: #dbdbdb;
@@ -2663,13 +2677,13 @@ infobar {
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
 
-row:selected button.flat, row:selected button.sidebar-button, infobar.info button.flat, infobar.info button.sidebar-button, infobar.question button.flat, infobar.question button.sidebar-button, infobar.warning button.flat, infobar.warning button.sidebar-button, infobar.error button.flat, infobar.error button.sidebar-button {
+row:selected button.flat, infobar.info button.flat, infobar.question button.flat, infobar.warning button.flat, infobar.error button.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, row:selected button.flat:disabled, row:selected button.sidebar-button:disabled, infobar.info button.flat:disabled, infobar.info button.sidebar-button:disabled, infobar.question button.flat:disabled, infobar.question button.sidebar-button:disabled, infobar.warning button.flat:disabled, infobar.warning button.sidebar-button:disabled, infobar.error button.flat:disabled, infobar.error button.sidebar-button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled label, row:selected button.sidebar-button:disabled label, infobar.info button.flat:disabled label, infobar.info button.sidebar-button:disabled label, infobar.question button.flat:disabled label, infobar.question button.sidebar-button:disabled label, infobar.warning button.flat:disabled label, infobar.warning button.sidebar-button:disabled label, infobar.error button.flat:disabled label, infobar.error button.sidebar-button:disabled label {
+  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
 row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
@@ -2677,7 +2691,7 @@ row:selected button:hover, infobar.info button:hover, infobar.question button:ho
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, .primary-toolbar toolbar.selection-mode button:hover:active, .primary-toolbar .selection-mode.inline-toolbar button:hover:active, .selection-mode.primary-toolbar button:hover:active, headerbar.selection-mode button:hover:active, .primary-toolbar toolbar.selection-mode button:hover:checked, .primary-toolbar .selection-mode.inline-toolbar button:hover:checked, .selection-mode.primary-toolbar button:hover:checked, headerbar.selection-mode button:hover:checked, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
   color: #92b372;
   background-color: #ffffff;
   border-color: #ffffff; }
@@ -2687,7 +2701,7 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
   border-color: rgba(255, 255, 255, 0.4); }
   row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+  .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
     color: #92b372;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2976,10 +2990,10 @@ filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-windo
   filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
   filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
     color: #ffffff; }
-    row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
+    label:disabled selection, row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
     textview text:disabled:selected, iconview text:disabled:selected:focus,
     textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
-    textview text selection:disabled, flowbox flowboxchild:disabled:selected, label:disabled selection, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    textview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
@@ -3075,12 +3089,15 @@ vte-terminal {
 .nautilus-canvas-item {
   border-radius: 2px; }
 
-.nautilus-desktop.nautilus-canvas-item, .nemo-desktop.nemo-canvas-item {
+.nemo-desktop.nemo-canvas-item,
+.nautilus-desktop.nautilus-canvas-item {
   color: #ffffff;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
-  .nautilus-desktop.nautilus-canvas-item:active, .nemo-desktop.nemo-canvas-item:active {
+  .nemo-desktop.nemo-canvas-item:active,
+  .nautilus-desktop.nautilus-canvas-item:active {
     color: #303030; }
-  .nautilus-desktop.nautilus-canvas-item:selected, .nemo-desktop.nemo-canvas-item:selected {
+  .nemo-desktop.nemo-canvas-item:selected,
+  .nautilus-desktop.nautilus-canvas-item:selected {
     color: #ffffff; }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
@@ -3921,13 +3938,13 @@ filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollba
 window.background.lightdm menubar > menuitem {
   padding: 0 5px 0 5px; }
 
-window.background.lightdm button.flat.option-button, window.background.lightdm button.option-button.sidebar-button {
+window.background.lightdm button.flat.option-button {
   background-color: transparent;
   color: #dadada; }
-  window.background.lightdm button.flat.option-button:hover, window.background.lightdm button.option-button.sidebar-button:hover {
+  window.background.lightdm button.flat.option-button:hover {
     border-color: rgba(189, 189, 189, 0.2);
     background-color: rgba(0, 0, 0, 0.5); }
-  window.background.lightdm button.flat.option-button:active, window.background.lightdm button.option-button.sidebar-button:active {
+  window.background.lightdm button.flat.option-button:active {
     border-color: #BDBDBD;
     background-color: #92b372;
     color: #ffffff; }

--- a/src/Mint-Y/gtk-3.0/sass/_applications.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_applications.scss
@@ -115,6 +115,7 @@ vte-terminal {
   border-radius: 2px;
 }
 
+%nautilus_canvas_item,
 .nautilus-desktop.nautilus-canvas-item {
   color: $selected_fg_color;
   text-shadow: 1px 1px transparentize(black, 0.4);
@@ -239,7 +240,7 @@ NautilusListView .view { border-bottom: 1px solid $borders_color; }
 //
 // Nemo
 //
-.nemo-desktop.nemo-canvas-item { @extend .nautilus-desktop.nautilus-canvas-item; }
+.nemo-desktop.nemo-canvas-item { @extend %nautilus_canvas_item; }
 
 .nemo-window {
 

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -128,7 +128,7 @@ label {
   &:disabled {
     color: $insensitive_fg_color;
 
-    selection { @extend %selected_items:disabled; }
+    selection { @extend %selected_items_disabled; }
   }
 }
 
@@ -345,6 +345,7 @@ button {
 
   separator { margin: 4px 1px; }
 
+  @at-root %button_basic_flat,
   &.flat {
     @include button(undecorated);
     // to avoid adiacent buttons borders clashing when transitioning, the transition on the normal state is set
@@ -380,6 +381,7 @@ button {
   &:active:hover, &:checked { color: $selected_fg_color; }
   //Webkitgtk workaround end
 
+  @at-root %button_basic_flat,
   &.flat:disabled { @include button(undecorated); }
 
   &:disabled {
@@ -423,6 +425,7 @@ button {
     &.popup { padding-right: 8px; padding-left: 8px; }
   }
 
+  @at-root %button_basic_drop_active,
   &:drop(active) {
     color: $drop_target_color;
     border-color: $drop_target_color;
@@ -595,9 +598,9 @@ button {
 // More inline toolbar buttons
 toolbar.inline-toolbar toolbutton {
   & > button.flat { @extend %linked_middle; }
-  &:first-child > button.flat { @extend %linked:first-child; }
-  &:last-child > button.flat { @extend %linked:last-child; }
-  &:only-child > button.flat { @extend %linked:only-child; }
+  &:first-child > button.flat { @extend %linked_left; }
+  &:last-child > button.flat { @extend %linked_right; }
+  &:only-child > button.flat { @extend %linked_only_child; }
 }
 
 %linked_middle {
@@ -605,21 +608,32 @@ toolbar.inline-toolbar toolbutton {
   border-right-style: none;
 }
 
+%linked_left {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+%linked_right {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-right-style: solid;
+}
+
+%linked_only_child {
+  border-radius: 3px;
+  border-style: solid;
+}
+
 %linked {
   @extend %linked_middle;
-  &:first-child {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-  }
-  &:last-child {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
-    border-right-style: solid;
-  }
-  &:only-child {
-    border-radius: 3px;
-    border-style: solid;
-  }
+
+  &:first-child { @extend %linked_left; }
+  &:last-child { @extend %linked_right; }
+  &:only-child { @extend %linked_only_child; }
 }
 
 %linked_vertical_middle {
@@ -627,21 +641,28 @@ toolbar.inline-toolbar toolbutton {
   border-bottom-style: none;
 }
 
-%linked_vertical{
+%linked_vertical_top {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
+%linked_vertical_bottom {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-bottom-style: solid;
+}
+
+%linked_vertical_only_child {
+  border-radius: 3px;
+  border-style: solid;
+}
+
+%linked_vertical {
   @extend %linked_vertical_middle;
-  &:first-child {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-  }
-  &:last-child {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
-    border-bottom-style: solid;
-  }
-  &:only-child {
-    border-radius: 3px;
-    border-style: solid;
-  }
+
+  &:first-child { @extend %linked_vertical_top; }
+  &:last-child { @extend %linked_vertical_bottom; }
+  &:only-child { @extend %linked_vertical_only_child; }
 }
 
 %undecorated_button {
@@ -683,6 +704,7 @@ modelbutton.flat arrow {
 //
 // Links
 //
+%link,
 *:link {
   color: $link_color;
 
@@ -708,7 +730,8 @@ modelbutton.flat arrow {
 
 button:link, button:visited {
   @extend %undecorated_button;
-  @extend *:link;
+  @extend %link;
+
   &:hover, &:active, &:checked {
     @extend %undecorated_button;
   }
@@ -792,7 +815,7 @@ combobox {
     min-width: 16px;
   }
 
-  &:drop(active) button.combo { @extend button:drop(active); }
+  &:drop(active) button.combo { @extend %button_basic_drop_active; }
 
   .linked:not(.vertical) > & > box > button.combo {
     // the combobox is a composite widget so the way we do button linking doesn't
@@ -801,14 +824,14 @@ combobox {
     &:dir(rtl) { @extend %linked_middle; }
   }
 
-  .linked:not(.vertical) > &:first-child > box > button.combo { @extend %linked:first-child; }
-  .linked:not(.vertical) > &:last-child > box > button.combo { @extend %linked:last-child; }
-  .linked:not(.vertical) > &:only-child > box > button.combo { @extend %linked:only-child; }
+  .linked:not(.vertical) > &:first-child > box > button.combo { @extend %linked_left; }
+  .linked:not(.vertical) > &:last-child > box > button.combo { @extend %linked_right; }
+  .linked:not(.vertical) > &:only-child > box > button.combo { @extend %linked_only_child; }
 
   .linked.vertical > & > box > button.combo { @extend %linked_vertical_middle; }
-  .linked.vertical > &:first-child > box > button.combo { @extend %linked_vertical:first-child; }
-  .linked.vertical > &:last-child > box > button.combo { @extend %linked_vertical:last-child; }
-  .linked.vertical > &:only-child > box > button.combo { @extend %linked_vertical:only-child; }
+  .linked.vertical > &:first-child > box > button.combo { @extend %linked_vertical_top; }
+  .linked.vertical > &:last-child > box > button.combo { @extend %linked_vertical_bottom; }
+  .linked.vertical > &:only-child > box > button.combo { @extend %linked_vertical_only_child; }
 }
 
 toolbar {
@@ -945,7 +968,7 @@ headerbar,
       color: transparentize($selected_fg_color, 0.4);
     }
 
-    .subtitle:link { @extend *:link:selected;  }
+    .subtitle:link { @extend %link_selected; }
 
     button {
       color: $selected_fg_color;
@@ -1149,13 +1172,13 @@ headerbar {
       color: $selection_mode_fg;
       background-color: transparentize($selection_mode_fg, 1);
     }
-    &:hover { @extend %normal_selected_button; }
-    &:active, &:checked { @extend %selected-button:active; }
+    &:hover { @extend %selected_button_normal; }
+    &:active, &:checked { @extend %selected_button_active; }
 
     &:disabled {
-      @extend %selected-button.flat:disabled;
+      @extend %selected_button_flat_disabled;
 
-      &:checked, &:active { @extend %selected-button:disabled:checked; }
+      &:checked, &:active { @extend %selected_button_disabled_checked; }
     }
   }
 
@@ -1663,7 +1686,11 @@ popover.background {
   .csd &, & { border: 1px solid darken($borders_color, 5%); }
 
   & separator { background-color: $_popover_bg; }
-  label.separator { @extend label.separator; } // Noice
+  label.separator {
+    @extend .dim-label;
+
+    color: $fg_color;
+  }
 
   > list,
   > .view,
@@ -2389,7 +2416,7 @@ row {
   &:selected {
     @extend %selected_items;
 
-    button { @extend %selected-button; }
+    button { @extend %selected_button; }
   }
 
   &.activatable {
@@ -2646,7 +2673,7 @@ placessidebar {
       margin-top: 2px;
       margin-bottom: 2px;
       padding: 0;
-      @extend button.flat;
+      @extend %button_basic_flat;
       border-radius: 100%;
       -gtk-outline-radius: 100%;
 
@@ -2766,7 +2793,7 @@ infobar {
     color: $selected_fg_color;
     caret-color: currentColor;
 
-    button { @extend %selected-button }
+    button { @extend %selected_button }
 
     selection {
       color: $selected_bg_color;
@@ -2788,9 +2815,9 @@ infobar {
 //
 // Buttons on selected backgrounds
 //
-%selected-button {
+%selected_button {
 
-  @at-root %normal_selected_button, & {
+  @at-root %selected_button_normal, & {
     color: $selected_fg_color;
     background-color: transparentize($selected_fg_color, 1);
     border-color: transparentize($selected_fg_color, 0.5);
@@ -2801,6 +2828,7 @@ infobar {
     color: $selected_fg_color;
     background-color: transparentize($selected_fg_color, 1);
 
+    @at-root %selected_button_flat_disabled,
     &:disabled {
       &, label { color: transparentize($selected_fg_color, 0.6); }
     }
@@ -2810,6 +2838,7 @@ infobar {
     background-color: transparentize($selected_fg_color, 0.8);
     border-color: transparentize($selected_fg_color, 0.2);
   }
+  @at-root %selected_button_active,
   &:active, &:active:hover, &:checked {
     color: $selected_bg_color;
     background-color: $selected_fg_color;
@@ -2820,6 +2849,7 @@ infobar {
     background-color: transparentize($selected_fg_color, 1);
     border-color: transparentize($selected_fg_color, 0.6);
 
+    @at-root %selected_button_disabled_checked,
     &:active, &:checked {
       color: $selected_bg_color;
       background-color: transparentize($selected_fg_color, 0.5);
@@ -3141,6 +3171,7 @@ headerbar,
   @at-root %nobg_selected_items, & {
     color: $selected_fg_color;
 
+    @at-root %selected_items_disabled,
     &:disabled { color: mix($selected_fg_color, $selected_bg_color, 50%); }
   }
 }


### PR DESCRIPTION
Extends using compound selectors cause issues with libsass 3.6.2 and later.
Remove these selectors to get around the issue.