### PR TITLE
Mint-X-Gtk3: Populate selected colors

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-widgets.css
@@ -23,6 +23,12 @@
     color: @theme_fg_color;
 }
 
+*:selected,
+*:selected:focus {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+}
+
 *:disabled {
     color: @insensitive_fg_color;
     text-shadow: 0 1px alpha(white, 0.4);


### PR DESCRIPTION
Intended use case here is for gtk:bg/fg[SELECTED] to be populated for metacity themes so they may integrate with the gtk3 theme.

It's a bit heavy handed, but not without precedent. These lines were commented out in 3855c033ac61973737d4ad7849285e86b90a8eec and removed in 117930a30bf7e13494ba010d4236cc313f421843.