### PR TITLE
Mint-Y themes: change px's to em's

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1020,10 +1020,10 @@ StScrollBar {
   padding-right: 30px;
   padding-left: 28px;
   text-align: right;
-  height: 30px; }
+  height: 2.2em; }
   .menu-selected-app-box:rtl {
     padding-top: 10px;
-    height: 30px; }
+    height: 2.2em; }
 
 .menu-selected-app-title {
   font-weight: bold; }


### PR DESCRIPTION
The .menu-selected-app-box style should use em's instead of px's to take account of changes to text scaling factor or default font size. This solves the problem of the description disappearing off the bottom of the menu when a larger font or font scaling is used. The value used is 2.2em so that the menu appears the same as it would if no changes to font size are made from the fresh install default (ubuntu regular, 10 and text scaling: 1.0)