### PR TITLE
Make tooltips fit dark theme

### DIFF
--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -2705,12 +2705,12 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
 
 tooltip,
 .tooltip {
-  color: #4a4a4a;
+  color: #dbdbdb;
   border-radius: 2px;
-  border: 1px solid #d0d0d0; }
+  border: 1px solid #292929; }
   tooltip.background,
   .tooltip.background {
-    background-color: #fbeaa0;
+    background-color: #383838;
     background-clip: padding-box; }
     tooltip.background label,
     .tooltip.background label {
@@ -2721,7 +2721,7 @@ tooltip,
   tooltip *,
   .tooltip * {
     background-color: transparent;
-    color: #4a4a4a; }
+    color: #dbdbdb; }
 
 colorswatch, colorswatch:drop(active) {
   border-style: none; }


### PR DESCRIPTION
![Screenshot_2021-01-18_00-35-45](https://user-images.githubusercontent.com/18582007/104877344-a282a680-5927-11eb-99cb-508fd6d77427.png)
This happens with firefox with the current version.
It is not readable.


![Screenshot_2021-01-18_00-55-13](https://user-images.githubusercontent.com/18582007/104877445-d6f66280-5927-11eb-851f-29407bcc635a.png)
With the change, this happens.