### PR TITLE
Fix broad libhandy1 headerbar issue for Mint-Y (and variants)

### DIFF
--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -55,7 +55,7 @@ textview text {
 textview border {
   background-color: #3c3c3c; }
 
-rubberband, flowbox rubberband, treeview.view rubberband, .content-view rubberband,
+rubberband, .content-view rubberband, treeview.view rubberband, flowbox rubberband,
 .rubberband {
   border: 1px solid #76905b;
   background-color: rgba(118, 144, 91, 0.2); }
@@ -76,8 +76,8 @@ label selection {
 label:disabled {
   color: rgba(218, 218, 218, 0.55); }
 
-.dim-label, label.separator, popover label.separator,
-popover.background label.separator {
+.dim-label, popover label.separator,
+popover.background label.separator, label.separator {
   color: rgba(218, 218, 218, 0.65); }
 
 assistant .sidebar {
@@ -102,9 +102,9 @@ textview {
   background-color: #3c3c3c;
   color: #DADADA; }
 
-popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
+.osd .scale-popup, popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
 popover.background.osd,
-popover.background.magnifier, .csd popover.background.osd, .csd popover.background.magnifier, .osd .scale-popup, .osd {
+popover.background.magnifier, .csd popover.background.osd, .csd popover.background.magnifier, .osd {
   color: #dbdbdb;
   border: none;
   background-color: #353535;
@@ -314,13 +314,16 @@ button {
   .titlebar button.text-button.titlebutton {
     padding-left: 5px;
     padding-right: 5px; }
-    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child, .titlebar button.text-button.titlebutton label:first-child {
+    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child,
+    .titlebar button.text-button.titlebutton label:first-child {
       padding-left: 8px;
       padding-right: 2px; }
-    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child, .titlebar button.text-button.titlebutton label:last-child {
+    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child,
+    .titlebar button.text-button.titlebutton label:last-child {
       padding-right: 8px;
       padding-left: 2px; }
-    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child, .titlebar button.text-button.titlebutton label:only-child {
+    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child,
+    .titlebar button.text-button.titlebutton label:only-child {
       padding-left: 8px;
       padding-right: 8px; }
     button.text-button.image-button.popup, headerbar button.text-button.popup.titlebutton,
@@ -392,8 +395,7 @@ button {
         outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(22, 22, 22, 0.4);
         background-color: #8fa876; }
-  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
-  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
+  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child), .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
@@ -528,94 +530,70 @@ button {
     .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
       color: inherit; }
 
-toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, .linked:not(.vertical) > entry,
-.linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button,
-.linked:not(.vertical) > button:hover,
-.linked:not(.vertical) > button:active,
-.linked:not(.vertical) > button:checked, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .linked:not(.vertical).path-bar > button,
-headerbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
-.primary-toolbar .linked:not(.vertical).path-bar > button:hover,
-headerbar .linked:not(.vertical).path-bar > button:hover,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
-.primary-toolbar .linked:not(.vertical).path-bar > button:active,
-headerbar .linked:not(.vertical).path-bar > button:active,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
-.primary-toolbar .linked:not(.vertical).path-bar > button:checked,
-headerbar .linked:not(.vertical).path-bar > button:checked,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
-.primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
-headerbar .linked:not(.vertical).path-bar > button:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl) {
+.linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl),
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button,
+headerbar .linked.path-bar:not(.vertical) > button, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .linked:not(.vertical) > entry, .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button, .linked:not(.vertical) > button:hover, .linked:not(.vertical) > button:active, .linked:not(.vertical) > button:checked, toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat {
   border-radius: 0;
   border-right-style: none; }
 
-toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
-headerbar .linked:not(.vertical).path-bar > button:first-child,
-headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:first-child:active,
-headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled, .linked:not(.vertical) > combobox:first-child > box > button.combo {
+popover.combo scrollbar.vertical:dir(rtl), .linked:not(.vertical) > combobox:first-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:first-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:first-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:first-child,
+headerbar .linked.path-bar:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .inline-toolbar button:first-child:backdrop, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat {
   border-top-left-radius: 3px;
   border-bottom-left-radius: 3px;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0; }
 
-toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
-headerbar .linked:not(.vertical).path-bar > button:last-child,
-headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:last-child:active,
-headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox:last-child > box > button.combo {
+popover.combo scrollbar.vertical:dir(ltr), .linked:not(.vertical) > combobox:last-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:last-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:last-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:last-child,
+headerbar .linked.path-bar:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .inline-toolbar button:last-child:backdrop, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat {
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-right-style: solid; }
 
-toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
-headerbar .linked:not(.vertical).path-bar > button:only-child,
-headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:only-child:active,
-headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled, .linked:not(.vertical) > combobox:only-child > box > button.combo {
+.linked:not(.vertical) > combobox:only-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:only-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:only-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:only-child,
+headerbar .linked.path-bar:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .inline-toolbar button:only-child:backdrop, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat {
   border-radius: 3px;
   border-style: solid; }
 
-.linked.vertical > entry,
-.linked.vertical > entry:focus, .linked.vertical > button,
-.linked.vertical > button:hover,
-.linked.vertical > button:active,
-.linked.vertical > button:checked, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > combobox > box > button.combo {
+.linked.vertical > combobox > box > button.combo, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > entry, .linked.vertical > entry:focus, .linked.vertical > button, .linked.vertical > button:hover, .linked.vertical > button:active, .linked.vertical > button:checked {
   border-radius: 0;
   border-bottom-style: none; }
 
-.linked.vertical > entry:first-child, .linked.vertical > button:first-child, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > combobox:first-child > box > button.combo {
+list.content > row:first-child, list.content > row.expander:first-child row.header, list.content > row.expander:checked, list.content > row.expander:checked row.header, list.content > row.expander:checked + row, list.content > row.expander:checked + row.expander row.header, popover.combo overshoot.top, popover.combo list > row:first-child, .linked.vertical > combobox:first-child > box > button.combo, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > entry:first-child, .linked.vertical > button:first-child {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px; }
 
-.linked.vertical > entry:last-child, .linked.vertical > button:last-child, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > combobox:last-child > box > button.combo {
+list.content > row:last-child, list.content > row.checked-expander-row-previous-sibling, list.content > row.expander:checked, list.content > row.expander:not(:checked):last-child row.header, list.content > row.expander.checked-expander-row-previous-sibling:not(:checked) row.header, list.content > row.expander.empty:checked row.header, list.content > row.expander list.nested > row:last-child, popover.combo overshoot.bottom, popover.combo list > row:last-child, .linked.vertical > combobox:last-child > box > button.combo, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > entry:last-child, .linked.vertical > button:last-child {
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
   border-bottom-style: solid; }
 
-.linked.vertical > entry:only-child, .linked.vertical > button:only-child, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > combobox:only-child > box > button.combo {
+.linked.vertical > combobox:only-child > box > button.combo, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > entry:only-child, .linked.vertical > button:only-child {
   border-radius: 3px;
   border-style: solid; }
 
-menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, .app-notification button.flat, .app-notification button.flat:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, .app-notification button.flat:disabled, .app-notification button.flat, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.flat:hover, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, menuitem.button.flat,
+modelbutton.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -658,28 +636,21 @@ button:link, button:visited,
   button:visited,
   *:link:visited {
     color: #5294E2; }
-    *:selected button:visited, *:selected
-    *:link:visited {
+    *:selected button:visited, *:selected *:link:visited {
       color: #d2dcc8; }
   button:hover:link, button:hover:visited,
   *:link:hover {
     color: #7eafe9; }
-    *:selected button:hover:link, *:selected button:hover:visited, *:selected
-    *:link:hover {
+    *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover {
       color: #f4f6f1; }
   button:active:link, button:active:visited,
   *:link:active {
     color: #5294E2; }
-    *:selected button:active:link, *:selected button:active:visited, *:selected
-    *:link:active {
+    *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active {
       color: #e9eee4; }
-  headerbar.selection-mode .subtitle:link,
-  .selection-mode.titlebar:not(headerbar) .subtitle:link, infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, button:selected:link, button:selected:visited,
-  *:selected button:link,
-  *:selected button:visited,
-  *:link:selected,
-  *:selected
-  *:link {
+  infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, button:selected:link, button:selected:visited, *:selected button:link, *:selected button:visited,
+  *:link:selected, *:selected *:link {
     color: #e9eee4; }
 
 button:link > label, button:visited > label {
@@ -697,8 +668,7 @@ spinbutton:disabled {
 spinbutton:not(.vertical) entry {
   min-width: 28px; }
 
-spinbutton:not(.vertical):dir(ltr) entry,
-spinbutton:not(.vertical):dir(rtl) button.up {
+spinbutton:not(.vertical):dir(ltr) entry, spinbutton:not(.vertical):dir(rtl) button.up {
   border-radius: 3px 0 0 3px; }
 
 spinbutton:not(.vertical) > button + button {
@@ -919,28 +889,18 @@ headerbar,
         -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
     .maximized headerbar.selection-mode, .maximized .selection-mode.titlebar:not(headerbar) {
       background-color: #8fa876; }
-  .tiled headerbar, .tiled headerbar:backdrop,
-  .maximized headerbar, .maximized headerbar:backdrop, .tiled .titlebar:not(headerbar), .tiled .titlebar:backdrop:not(headerbar),
-  .maximized .titlebar:not(headerbar), .maximized .titlebar:backdrop:not(headerbar) {
+  .tiled headerbar, .tiled headerbar:backdrop, .maximized headerbar, .maximized headerbar:backdrop, .tiled .titlebar:not(headerbar), .maximized .titlebar:not(headerbar) {
     border-radius: 0; }
-  .maximized headerbar,
-  .maximized .titlebar:not(headerbar) {
+  .maximized headerbar, .maximized .titlebar:not(headerbar) {
     background-color: #2f2f2f;
     border-color: #252525; }
-  headerbar.default-decoration,
-  .csd headerbar.default-decoration, headerbar.default-decoration:backdrop,
-  .csd headerbar.default-decoration:backdrop,
-  .default-decoration.titlebar:not(headerbar),
-  .csd .default-decoration.titlebar:not(headerbar),
-  .default-decoration.titlebar:backdrop:not(headerbar),
-  .csd .default-decoration.titlebar:backdrop:not(headerbar) {
+  headerbar.default-decoration, .csd headerbar.default-decoration, headerbar.default-decoration:backdrop, .csd headerbar.default-decoration:backdrop,
+  .default-decoration.titlebar:not(headerbar) {
     min-height: 28px;
     padding: 0 7px;
     background-color: #2f2f2f;
     border-bottom-width: 0; }
-    .maximized headerbar.default-decoration, .maximized
-    .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized
-    .csd headerbar.default-decoration:backdrop, .maximized .default-decoration.titlebar:not(headerbar), .maximized .csd .default-decoration.titlebar:not(headerbar), .maximized .default-decoration.titlebar:backdrop:not(headerbar), .maximized .csd .default-decoration.titlebar:backdrop:not(headerbar) {
+    .maximized headerbar.default-decoration, .maximized .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized .csd headerbar.default-decoration:backdrop, .maximized .default-decoration.titlebar:not(headerbar) {
       background-color: #2f2f2f; }
 
 .titlebar {
@@ -952,23 +912,15 @@ headerbar entry, headerbar button, headerbar separator {
 
 separator:first-child + headerbar, separator:first-child + headerbar:backdrop, headerbar:first-child, headerbar:first-child:backdrop {
   border-top-left-radius: 3px; }
-  .maximized separator:first-child + headerbar,
-  .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop,
-  .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child,
-  .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop,
-  .tiled headerbar:first-child:backdrop {
+  .maximized separator:first-child + headerbar, .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop, .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child, .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop, .tiled headerbar:first-child:backdrop {
     border-radius: 0; }
 
 headerbar:last-child, headerbar:last-child:backdrop {
   border-top-right-radius: 3px; }
-  .maximized headerbar:last-child,
-  .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop,
-  .tiled headerbar:last-child:backdrop {
+  .maximized headerbar:last-child, .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop, .tiled headerbar:last-child:backdrop {
     border-radius: 0; }
 
-window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop,
-window.csd > .titlebar:not(headerbar),
-window.csd > .titlebar:not(headerbar):backdrop {
+window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop, window.csd > .titlebar:not(headerbar), window.csd > .titlebar:not(headerbar):backdrop {
   padding: 0;
   background: none;
   border: none;
@@ -977,354 +929,434 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .titlebar:not(headerbar) > separator {
   background-image: linear-gradient(to bottom, #252525, #252525); }
 
-.primary-toolbar toolbar separator, .primary-toolbar .inline-toolbar separator,
-.primary-toolbar:not(.libreoffice-toolbar) separator {
+.primary-toolbar toolbar separator,
+.primary-toolbar:not(.libreoffice-toolbar) separator, .primary-toolbar .inline-toolbar separator {
   min-width: 1px;
   min-height: 1px;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(222, 214, 214, 0) 25%, rgba(222, 214, 214, 0.35) 25%, rgba(222, 214, 214, 0.35) 75%, rgba(222, 214, 214, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar toolbar separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop,
-  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop {
+  .primary-toolbar toolbar separator:backdrop,
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop {
     opacity: 0.6; }
 
-.primary-toolbar toolbar entry, .primary-toolbar .inline-toolbar entry, .primary-toolbar entry, headerbar entry {
+
+.primary-toolbar entry, headerbar entry {
   color: #ded6d6;
   border-color: rgba(16, 16, 16, 0.4);
   background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar entry image, .primary-toolbar .inline-toolbar entry image, .primary-toolbar entry image, headerbar entry image, .primary-toolbar toolbar entry image:hover, .primary-toolbar .inline-toolbar entry image:hover, .primary-toolbar entry image:hover, headerbar entry image:hover {
+  
+  .primary-toolbar entry image, headerbar entry image {
     color: inherit; }
-  .primary-toolbar toolbar entry:backdrop, .primary-toolbar .inline-toolbar entry:backdrop, .primary-toolbar entry:backdrop, headerbar entry:backdrop {
+  
+  .primary-toolbar entry:backdrop, headerbar entry:backdrop {
     opacity: 0.85; }
-  .primary-toolbar toolbar entry:focus, .primary-toolbar .inline-toolbar entry:focus, .primary-toolbar entry:focus, headerbar entry:focus {
+  
+  .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ded6d6;
     border-color: #8fa876;
     background-color: rgba(103, 103, 103, 0.4);
     background-clip: padding-box; }
-    .primary-toolbar toolbar entry:focus image, .primary-toolbar .inline-toolbar entry:focus image, .primary-toolbar entry:focus image, headerbar entry:focus image {
+    
+    .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: rgba(222, 214, 214, 0.85); }
-  .primary-toolbar toolbar entry:disabled, .primary-toolbar .inline-toolbar entry:disabled, .primary-toolbar entry:disabled, headerbar entry:disabled {
+  
+  .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(103, 103, 103, 0.25); }
-  .primary-toolbar toolbar entry selection:focus, .primary-toolbar .inline-toolbar entry selection:focus, .primary-toolbar entry selection:focus, headerbar entry selection:focus {
+  
+  .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #8fa876;
     color: #ffffff; }
-  .primary-toolbar toolbar entry progress, .primary-toolbar .inline-toolbar entry progress, .primary-toolbar entry progress, headerbar entry progress {
+  
+  .primary-toolbar entry progress, headerbar entry progress {
     border-color: #8fa876;
     background-image: none;
     background-color: transparent; }
-  .primary-toolbar toolbar entry.warning, .primary-toolbar .inline-toolbar entry.warning, .primary-toolbar entry.warning, headerbar entry.warning {
+  
+  .primary-toolbar entry.warning, headerbar entry.warning {
     color: white;
     border-color: rgba(16, 16, 16, 0.4);
     background-color: #a45b33; }
-    .primary-toolbar toolbar entry.warning:focus, .primary-toolbar .inline-toolbar entry.warning:focus, .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
+    
+    .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
       color: white;
       background-color: #f27835; }
-    .primary-toolbar toolbar entry.warning selection, .primary-toolbar .inline-toolbar entry.warning selection, .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar toolbar entry.warning selection:focus, .primary-toolbar .inline-toolbar entry.warning selection:focus, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
+    
+    .primary-toolbar entry.warning selection, headerbar entry.warning selection {
       background-color: white;
       color: #f27835; }
-  .primary-toolbar toolbar entry.error, .primary-toolbar .inline-toolbar entry.error, .primary-toolbar entry.error, headerbar entry.error {
+  
+  .primary-toolbar entry.error, headerbar entry.error {
     color: white;
     border-color: rgba(16, 16, 16, 0.4);
     background-color: #aa3a34; }
-    .primary-toolbar toolbar entry.error:focus, .primary-toolbar .inline-toolbar entry.error:focus, .primary-toolbar entry.error:focus, headerbar entry.error:focus {
+    
+    .primary-toolbar entry.error:focus, headerbar entry.error:focus {
       color: white;
       background-color: #FC4138; }
-    .primary-toolbar toolbar entry.error selection, .primary-toolbar .inline-toolbar entry.error selection, .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar toolbar entry.error selection:focus, .primary-toolbar .inline-toolbar entry.error selection:focus, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
+    
+    .primary-toolbar entry.error selection, headerbar entry.error selection {
       background-color: white;
       color: #FC4138; }
 
-.primary-toolbar toolbar button, .primary-toolbar .inline-toolbar button, .primary-toolbar button, headerbar button {
+
+.primary-toolbar button, headerbar button {
   color: #ded6d6;
   outline-color: rgba(222, 214, 214, 0.3);
   outline-offset: -3px;
   background-color: rgba(47, 47, 47, 0);
   border-color: rgba(47, 47, 47, 0); }
-  .primary-toolbar toolbar button:backdrop, .primary-toolbar .inline-toolbar button:backdrop, .primary-toolbar button:backdrop, headerbar button:backdrop {
+  
+  .primary-toolbar button:backdrop, headerbar button:backdrop {
     opacity: 0.7; }
-  .primary-toolbar toolbar button:hover, .primary-toolbar .inline-toolbar button:hover, .primary-toolbar button:hover, headerbar button:hover {
+  
+  .primary-toolbar button:hover, headerbar button:hover {
     color: #ded6d6;
     outline-color: rgba(222, 214, 214, 0.3);
     border-color: rgba(16, 16, 16, 0.4);
     background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar button:active, .primary-toolbar .inline-toolbar button:active, .primary-toolbar button:active, headerbar button:active, .primary-toolbar toolbar button:checked, .primary-toolbar .inline-toolbar button:checked, .primary-toolbar button:checked, headerbar button:checked {
+  
+  .primary-toolbar button:active, headerbar button:active,
+  .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #8fa876;
     background-clip: padding-box; }
-  .primary-toolbar toolbar button:disabled, .primary-toolbar .inline-toolbar button:disabled, .primary-toolbar button:disabled, headerbar button:disabled {
+  
+  .primary-toolbar button:disabled, headerbar button:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button:disabled label, .primary-toolbar .inline-toolbar button:disabled label, .primary-toolbar button:disabled label, headerbar button:disabled label {
+    
+    .primary-toolbar button:disabled label, headerbar button:disabled label {
       color: inherit; }
-  .primary-toolbar toolbar button:disabled:active, .primary-toolbar .inline-toolbar button:disabled:active, .primary-toolbar button:disabled:active, headerbar button:disabled:active, .primary-toolbar toolbar button:disabled:checked, .primary-toolbar .inline-toolbar button:disabled:checked, .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
+  
+  .primary-toolbar button:disabled:active, headerbar button:disabled:active,
+  .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
     color: rgba(255, 255, 255, 0.75);
     border-color: rgba(143, 168, 118, 0.65);
     background-color: rgba(143, 168, 118, 0.65); }
 
-.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat {
+.primary-toolbar toolbar.selection-mode button,
+.selection-mode.primary-toolbar button, .primary-toolbar .selection-mode.inline-toolbar button, headerbar.selection-mode button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
 
+
 .primary-toolbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child), headerbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child) {
   margin-right: 1px; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, headerbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:active, headerbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, headerbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked:not(.vertical):not(.path-bar) > button:disabled {
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
+
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
 .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
 .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
 headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
 .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
 .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .linked:not(.vertical).path-bar > button,
-headerbar .linked:not(.vertical).path-bar > button {
+.primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button,
+headerbar .linked.path-bar:not(.vertical) > button {
   color: #ded6d6;
   outline-color: rgba(222, 214, 214, 0.3);
   border-color: rgba(16, 16, 16, 0.4);
   background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:hover,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:hover,
-  headerbar .linked:not(.vertical).path-bar > button:hover {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:hover,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:hover,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:hover,
+  headerbar .linked.path-bar:not(.vertical) > button:hover {
     background-color: rgba(141, 141, 141, 0.4); }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:active,
-  headerbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:checked,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:checked,
-  headerbar .linked:not(.vertical).path-bar > button:checked {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:active,
+  headerbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:checked,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:checked,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:checked,
+  headerbar .linked.path-bar:not(.vertical) > button:checked {
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #8fa876; }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:disabled,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
-  headerbar .linked:not(.vertical).path-bar > button:disabled {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  headerbar .linked.path-bar:not(.vertical) > button:disabled {
     color: rgba(222, 214, 214, 0.6); }
 
-.primary-toolbar toolbar .linked:not(.vertical) entry, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry, .primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
+
+.primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
   box-shadow: none; }
-  .primary-toolbar toolbar .linked:not(.vertical) entry:focus, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry:focus, .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
+  
+  .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
     color: #ded6d6;
     border-color: rgba(16, 16, 16, 0.4);
     background-color: rgba(103, 103, 103, 0.4);
     background-clip: padding-box; }
-    .primary-toolbar toolbar .linked:not(.vertical) entry:focus image, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry:focus image, .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image, .primary-toolbar .linked:not(.vertical) entry:focus image:hover, headerbar .linked:not(.vertical) entry:focus image:hover {
+    
+    .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image {
       color: inherit; }
-  .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
+  
+  .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
     color: #ded6d6;
     outline-color: rgba(222, 214, 214, 0.3);
     border-color: rgba(16, 16, 16, 0.4);
     background-color: rgba(103, 103, 103, 0.4); }
+    
     .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover {
       background-color: rgba(141, 141, 141, 0.4); }
-    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
+    
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active,
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
       color: #ffffff;
       outline-color: rgba(255, 255, 255, 0.3);
       border-color: transparent;
       background-color: #8fa876; }
+    
     .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
       color: rgba(222, 214, 214, 0.6);
       background-color: rgba(103, 103, 103, 0.2);
       border-color: rgba(16, 16, 16, 0.4); }
+      
       .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled:checked, headerbar .linked:not(.vertical) entry + button:last-child:disabled:checked {
         background-color: rgba(143, 168, 118, 0.65);
         color: rgba(255, 255, 255, 0.75); }
 
-.primary-toolbar toolbar button.suggested-action, .primary-toolbar .inline-toolbar button.suggested-action, .primary-toolbar button.suggested-action, headerbar button.suggested-action {
+
+.primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
   color: #ffffff;
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #6db442;
   border-color: #6db442; }
-  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
+  
+  .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     color: #6db442;
     outline-color: rgba(109, 180, 66, 0.3); }
-  .primary-toolbar toolbar button.suggested-action:hover, .primary-toolbar .inline-toolbar button.suggested-action:hover, .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
+  
+  .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #88c663;
     border-color: #88c663; }
-  .primary-toolbar toolbar button.suggested-action:active, .primary-toolbar .inline-toolbar button.suggested-action:active, .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar toolbar button.suggested-action:checked, .primary-toolbar .inline-toolbar button.suggested-action:checked, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
+  
+  .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active,
+  .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #568f34;
     border-color: #568f34; }
-  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+  
+  .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+    
+    .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
       color: inherit; }
 
-.primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop, .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
+
+.primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
   opacity: 0.8; }
 
-.primary-toolbar toolbar button.destructive-action, .primary-toolbar .inline-toolbar button.destructive-action, .primary-toolbar button.destructive-action, headerbar button.destructive-action {
+
+.primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
   color: #ffffff;
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #F04A50;
   border-color: #F04A50; }
-  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
+  
+  .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     color: #F04A50;
     outline-color: rgba(240, 74, 80, 0.3); }
-  .primary-toolbar toolbar button.destructive-action:hover, .primary-toolbar .inline-toolbar button.destructive-action:hover, .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
+  
+  .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #f4797e;
     border-color: #f4797e; }
-  .primary-toolbar toolbar button.destructive-action:active, .primary-toolbar .inline-toolbar button.destructive-action:active, .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar toolbar button.destructive-action:checked, .primary-toolbar .inline-toolbar button.destructive-action:checked, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
+  
+  .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active,
+  .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #ec1b22;
     border-color: #ec1b22; }
-  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+  
+  .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+    
+    .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
       color: inherit; }
 
-.primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop, .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
+
+.primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
   opacity: 0.8; }
 
-.primary-toolbar toolbar spinbutton:focus button, .primary-toolbar .inline-toolbar spinbutton:focus button, .primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
+
+.primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
   color: #ffffff; }
-  .primary-toolbar toolbar spinbutton:focus button:hover, .primary-toolbar .inline-toolbar spinbutton:focus button:hover, .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
+  
+  .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
     background-color: rgba(255, 255, 255, 0.1);
     border-color: transparent; }
-  .primary-toolbar toolbar spinbutton:focus button:disabled, .primary-toolbar .inline-toolbar spinbutton:focus button:disabled, .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
+  
+  .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
     color: rgba(255, 255, 255, 0.4); }
 
-.primary-toolbar toolbar spinbutton button, .primary-toolbar .inline-toolbar spinbutton button, .primary-toolbar spinbutton button, headerbar spinbutton button {
+
+.primary-toolbar spinbutton button, headerbar spinbutton button {
   color: #ded6d6; }
-  .primary-toolbar toolbar spinbutton button:hover, .primary-toolbar .inline-toolbar spinbutton button:hover, .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
+  
+  .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
     background-color: rgba(222, 214, 214, 0.25);
     border-color: transparent; }
-  .primary-toolbar toolbar spinbutton button:disabled, .primary-toolbar .inline-toolbar spinbutton button:disabled, .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
+  
+  .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
     color: rgba(222, 214, 214, 0.7); }
-  .primary-toolbar toolbar spinbutton button:active, .primary-toolbar .inline-toolbar spinbutton button:active, .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
+  
+  .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
     background-color: rgba(0, 0, 0, 0.1); }
 
-.primary-toolbar toolbar combobox:disabled, .primary-toolbar .inline-toolbar combobox:disabled, .primary-toolbar combobox:disabled, headerbar combobox:disabled {
+
+.primary-toolbar combobox:disabled, headerbar combobox:disabled {
   color: rgba(222, 214, 214, 0.4); }
 
-.primary-toolbar toolbar combobox > .linked > button.combo, .primary-toolbar .inline-toolbar combobox > .linked > button.combo, .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
+
+.primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: #ded6d6;
   border-color: rgba(16, 16, 16, 0.4);
   background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar combobox > .linked > button.combo image, .primary-toolbar .inline-toolbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar toolbar combobox > .linked > button.combo image:hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo image:hover, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
+  
+  .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image {
     color: inherit; }
-  .primary-toolbar toolbar combobox > .linked > button.combo:hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:hover, .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
+  
+  .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ded6d6;
     border-color: #8fa876;
     background-color: rgba(103, 103, 103, 0.4);
     box-shadow: none; }
-  .primary-toolbar toolbar combobox > .linked > button.combo:disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:disabled, .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
+  
+  .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(103, 103, 103, 0.25); }
 
-.primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr), .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr), .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
+
+.primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
     box-shadow: none; }
 
-.primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl), .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl), .primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
+
+.primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
   border-left-style: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
     box-shadow: none; }
 
-.primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar combobox > .linked > button.combo:dir(ltr):hover, headerbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar combobox > .linked > button.combo:dir(ltr):active, headerbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar combobox > .linked > button.combo:dir(ltr):checked, headerbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):disabled, .primary-toolbar combobox > .linked > button.combo:dir(ltr):disabled, headerbar combobox > .linked > button.combo:dir(ltr):disabled {
+
+.primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr) {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0; }
 
-.primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar combobox > .linked > button.combo:dir(rtl):hover, headerbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar combobox > .linked > button.combo:dir(rtl):active, headerbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar combobox > .linked > button.combo:dir(rtl):checked, headerbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):disabled, .primary-toolbar combobox > .linked > button.combo:dir(rtl):disabled, headerbar combobox > .linked > button.combo:dir(rtl):disabled {
+
+.primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0; }
 
-.primary-toolbar toolbar switch:backdrop, .primary-toolbar .inline-toolbar switch:backdrop, .primary-toolbar switch:backdrop, headerbar switch:backdrop {
+
+.primary-toolbar switch:backdrop, headerbar switch:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar progressbar trough, .primary-toolbar .inline-toolbar progressbar trough, .primary-toolbar progressbar trough, headerbar progressbar trough {
+
+.primary-toolbar progressbar trough, headerbar progressbar trough {
   background-color: rgba(16, 16, 16, 0.4); }
 
-.primary-toolbar toolbar progressbar:backdrop, .primary-toolbar .inline-toolbar progressbar:backdrop, .primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
+
+.primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar scale:backdrop, .primary-toolbar .inline-toolbar scale:backdrop, .primary-toolbar scale:backdrop, headerbar scale:backdrop {
+
+.primary-toolbar scale:backdrop, headerbar scale:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar scale slider, .primary-toolbar .inline-toolbar scale slider, .primary-toolbar scale slider, headerbar scale slider {
+
+.primary-toolbar scale slider, headerbar scale slider {
   background-color: #494949;
   border-color: rgba(16, 16, 16, 0.7); }
-  .primary-toolbar toolbar scale slider:hover, .primary-toolbar .inline-toolbar scale slider:hover, .primary-toolbar scale slider:hover, headerbar scale slider:hover {
+  
+  .primary-toolbar scale slider:hover, headerbar scale slider:hover {
     background-color: #555555;
     border-color: rgba(16, 16, 16, 0.7); }
-  .primary-toolbar toolbar scale slider:active, .primary-toolbar .inline-toolbar scale slider:active, .primary-toolbar scale slider:active, headerbar scale slider:active {
+  
+  .primary-toolbar scale slider:active, headerbar scale slider:active {
     background-color: #8fa876;
     border-color: #8fa876; }
-  .primary-toolbar toolbar scale slider:disabled, .primary-toolbar .inline-toolbar scale slider:disabled, .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
+  
+  .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
     background-color: #414141;
     border-color: rgba(16, 16, 16, 0.7); }
 
-.primary-toolbar toolbar scale trough, .primary-toolbar .inline-toolbar scale trough, .primary-toolbar scale trough, headerbar scale trough {
+
+.primary-toolbar scale trough, headerbar scale trough {
   background-color: rgba(16, 16, 16, 0.4); }
-  .primary-toolbar toolbar scale trough:disabled, .primary-toolbar .inline-toolbar scale trough:disabled, .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
+  
+  .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
     background-color: rgba(16, 16, 16, 0.3); }
 
 .path-bar button.text-button, .path-bar button.image-button, .path-bar headerbar button.titlebutton, headerbar .path-bar button.titlebutton,
-.path-bar .titlebar button.titlebutton, .titlebar .path-bar button.titlebutton, .path-bar button {
+.path-bar .titlebar button.titlebutton,
+.titlebar .path-bar button.titlebutton, .path-bar button {
   padding-left: 6px;
   padding-right: 6px; }
 
-.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label, .path-bar .titlebar button.text-button.titlebutton label, .titlebar .path-bar button.text-button.titlebutton label {
+.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label,
+.path-bar .titlebar button.text-button.titlebutton label,
+.titlebar .path-bar button.text-button.titlebutton label {
   padding-left: 0;
   padding-right: 0; }
 
-.path-bar button.text-button.image-button label:last-child, .path-bar headerbar button.text-button.titlebutton label:last-child, headerbar .path-bar button.text-button.titlebutton label:last-child, .path-bar .titlebar button.text-button.titlebutton label:last-child, .titlebar .path-bar button.text-button.titlebutton label:last-child, .path-bar button label:last-child {
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child {
   padding-right: 10px; }
 
-.path-bar button.text-button.image-button label:first-child, .path-bar headerbar button.text-button.titlebutton label:first-child, headerbar .path-bar button.text-button.titlebutton label:first-child, .path-bar .titlebar button.text-button.titlebutton label:first-child, .titlebar .path-bar button.text-button.titlebutton label:first-child, .path-bar button label:first-child {
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child {
   padding-left: 10px; }
 
 .path-bar button.slider-button, .path-bar button:not(.image-button):not(.text-button) {
@@ -1362,9 +1394,9 @@ treeview.view {
     border-style: solid none;
     border-width: 1px;
     border-color: #b5c1a8; }
-    treeview.view:drop(active).after {
+    treeview.view.after:drop(active) {
       border-top-style: none; }
-    treeview.view:drop(active).before {
+    treeview.view.before:drop(active) {
       border-bottom-style: none; }
   treeview.view.expander {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
@@ -1457,23 +1489,16 @@ menu,
   border-radius: 0;
   background-color: #383838;
   border: 1px solid #292929; }
-  .csd menu, .csd
-  .menu {
+  .csd menu, .csd .menu {
     padding: 4px 0px;
     border-radius: 2px;
     border: none; }
-  menu separator,
-  .csd menu separator,
-  .menu separator,
-  .csd
-  .menu separator {
+  menu separator, .csd menu separator,
+  .menu separator, .csd .menu separator {
     margin: 2px 0;
     background-color: #292929; }
-  menu .separator:not(label),
-  .csd menu .separator:not(label),
-  .menu .separator:not(label),
-  .csd
-  .menu .separator:not(label) {
+  menu .separator:not(label), .csd menu .separator:not(label),
+  .menu .separator:not(label), .csd .menu .separator:not(label) {
     color: #383838; }
   menu menuitem,
   .menu menuitem {
@@ -1549,8 +1574,7 @@ popover.background {
   background-clip: border-box;
   background-color: #383838;
   box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.35); }
-  .csd popover, popover, .csd
-  popover.background,
+  .csd popover, popover, .csd popover.background,
   popover.background {
     border: 1px solid #1c1c1c; }
   popover separator,
@@ -1766,10 +1790,10 @@ scrollbar {
       min-height: 4px;
       background-color: darkgray;
       border: 1px solid rgba(0, 0, 0, 0.3); }
-    scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider {
+    scrollbar.overlay-indicator.vertical:not(.dragging):not(.hovering) slider {
       margin: 2px 0;
       min-height: 40px; }
-    scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider {
+    scrollbar.overlay-indicator.horizontal:not(.dragging):not(.hovering) slider {
       margin: 0 2px;
       min-width: 40px; }
   scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering {
@@ -1805,8 +1829,7 @@ infobar switch {
 
 headerbar switch,
 .primary-toolbar switch,
-.primary-toolbar toolbar switch,
-.primary-toolbar .inline-toolbar switch {
+.primary-toolbar toolbar switch {
   background-image: -gtk-scaled(url("assets/switch-header-dark.png"), url("assets/switch-header-dark@2.png")); }
 
 switch:checked {
@@ -1819,8 +1842,7 @@ infobar switch:checked {
 
 headerbar switch:checked,
 .primary-toolbar switch:checked,
-.primary-toolbar toolbar switch:checked,
-.primary-toolbar .inline-toolbar switch:checked {
+.primary-toolbar toolbar switch:checked {
   background-image: -gtk-scaled(url("assets/switch-active-header-dark.png"), url("assets/switch-active-header-dark@2.png")); }
 
 switch:disabled {
@@ -1833,8 +1855,7 @@ infobar switch:disabled {
 
 headerbar switch:disabled,
 .primary-toolbar switch:disabled,
-.primary-toolbar toolbar switch:disabled,
-.primary-toolbar .inline-toolbar switch:disabled {
+.primary-toolbar toolbar switch:disabled {
   background-image: -gtk-scaled(url("assets/switch-insensitive-header-dark.png"), url("assets/switch-insensitive-header-dark@2.png")); }
 
 switch:checked:disabled {
@@ -1847,8 +1868,7 @@ infobar switch:checked:disabled {
 
 headerbar switch:checked:disabled,
 .primary-toolbar switch:checked:disabled,
-.primary-toolbar toolbar switch:checked:disabled,
-.primary-toolbar .inline-toolbar switch:checked:disabled {
+.primary-toolbar toolbar switch:checked:disabled {
   background-image: -gtk-scaled(url("assets/switch-active-insensitive-header-dark.png"), url("assets/switch-active-insensitive-header-dark@2.png")); }
 
 .check,
@@ -2066,11 +2086,8 @@ radio {
   min-width: 16px;
   min-height: 16px;
   margin: 0 2px; }
-  check:only-child,
-  menu menuitem check,
-  radio:only-child,
-  menu menuitem
-  radio {
+  check:only-child, menu menuitem check,
+  radio:only-child, menu menuitem radio {
     margin: 0; }
 
 scale {
@@ -2116,24 +2133,16 @@ scale {
       .osd scale slider:active {
         background-color: #76905b;
         border-color: #76905b; }
-    menuitem:hover scale slider,
-    row:selected scale slider,
-    infobar scale slider {
+    menuitem:hover scale slider, row:selected scale slider, infobar scale slider {
       background-color: #ffffff;
       border-color: #ffffff; }
-      menuitem:hover scale slider:hover,
-      row:selected scale slider:hover,
-      infobar scale slider:hover {
+      menuitem:hover scale slider:hover, row:selected scale slider:hover, infobar scale slider:hover {
         background-color: #eef2ea;
         border-color: #eef2ea; }
-      menuitem:hover scale slider:active,
-      row:selected scale slider:active,
-      infobar scale slider:active {
+      menuitem:hover scale slider:active, row:selected scale slider:active, infobar scale slider:active {
         background-color: #c7d4bb;
         border-color: #c7d4bb; }
-      menuitem:hover scale slider:disabled,
-      row:selected scale slider:disabled,
-      infobar scale slider:disabled {
+      menuitem:hover scale slider:disabled, row:selected scale slider:disabled, infobar scale slider:disabled {
         background-color: #cdd8c1;
         border-color: #cdd8c1; }
   scale trough {
@@ -2148,17 +2157,13 @@ scale {
       outline-color: rgba(219, 219, 219, 0.2); }
       .osd scale trough highlight {
         background-color: #8fa876; }
-    menuitem:hover scale trough row:selected scale trough,
-    infobar scale trough {
+    menuitem:hover scale trough row:selected scale trough, infobar scale trough {
       background-color: rgba(0, 0, 0, 0.2); }
-      menuitem:hover scale trough row:selected scale trough highlight,
-      infobar scale trough highlight {
+      menuitem:hover scale trough row:selected scale trough highlight, infobar scale trough highlight {
         background-color: #ffffff; }
-        menuitem:hover scale trough row:selected scale trough highlight:disabled,
-        infobar scale trough highlight:disabled {
+        menuitem:hover scale trough row:selected scale trough highlight:disabled, infobar scale trough highlight:disabled {
           background-color: #cdd8c1; }
-      menuitem:hover scale trough row:selected scale trough:disabled,
-      infobar scale trough:disabled {
+      menuitem:hover scale trough row:selected scale trough:disabled, infobar scale trough:disabled {
         background-color: rgba(0, 0, 0, 0.1); }
   scale highlight {
     border-radius: 2.5px;
@@ -2225,15 +2230,13 @@ progressbar {
     background-color: #8fa876;
     border-radius: 0px;
     box-shadow: none; }
-    row:selected progressbar progress,
-    infobar progressbar progress {
+    row:selected progressbar progress, infobar progressbar progress {
       background-color: #ffffff; }
   progressbar trough {
     border: 1px solid #292929;
     border-radius: 2px;
     background-color: #2b2b2b; }
-    row:selected progressbar trough,
-    infobar progressbar trough {
+    row:selected progressbar trough, infobar progressbar trough {
       background-color: rgba(0, 0, 0, 0.2); }
 
 .osd .progressbar {
@@ -2405,7 +2408,7 @@ row.activatable:disabled {
 row.activatable:selected:active {
   color: #ffffff; }
 
-row.activatable:selected.has-open-popup, row.activatable:selected:hover {
+row.activatable.has-open-popup:selected, row.activatable:selected:hover {
   background-color: #81976a; }
 
 .app-notification {
@@ -2526,13 +2529,10 @@ filechooserbutton:drop(active) {
 .sidebar {
   border-style: none;
   background-color: #3d3d3d; }
-  stacksidebar.sidebar:dir(ltr) list,
-  stacksidebar.sidebar.left list,
-  stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left, .sidebar.left:dir(rtl) {
+  stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left {
     border-right: 1px solid #292929;
     border-left-style: none; }
-  stacksidebar.sidebar:dir(rtl) list,
-  stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
+  stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
     border-left: 1px solid #292929;
     border-right-style: none; }
   .sidebar list {
@@ -2550,7 +2550,7 @@ stacksidebar row {
     background-size: 70px;
     background-position: 4px;
     background-repeat: no-repeat; }
-  stacksidebar row.activatable:selected.needs-attention {
+  stacksidebar row.activatable.needs-attention:selected {
     background-image: radial-gradient(circle closest-side at 5% 25%, #ffffff 0%, #ffffff 100%, transparent 100%);
     background-size: 70px;
     background-position: 4px;
@@ -2669,7 +2669,8 @@ infobar {
   infobar.question {
     background-color: #55c1ec; }
 
-.primary-toolbar toolbar.selection-mode button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover, .selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
+.primary-toolbar toolbar.selection-mode button:hover,
+.selection-mode.primary-toolbar button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
@@ -2680,7 +2681,9 @@ row:selected button.flat, infobar.info button.flat, infobar.question button.flat
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
+  .primary-toolbar toolbar.selection-mode button:disabled,
+  .selection-mode.primary-toolbar button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label,
+  .selection-mode.primary-toolbar button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
 row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
@@ -2688,7 +2691,9 @@ row:selected button:hover, infobar.info button:hover, infobar.question button:ho
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+.primary-toolbar toolbar.selection-mode button:active,
+.selection-mode.primary-toolbar button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked,
+.selection-mode.primary-toolbar button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
   color: #8fa876;
   background-color: #ffffff;
   border-color: #ffffff; }
@@ -2698,7 +2703,9 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
   border-color: rgba(255, 255, 255, 0.4); }
   row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+  .primary-toolbar toolbar.selection-mode button:disabled:checked,
+  .selection-mode.primary-toolbar button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active,
+  .selection-mode.primary-toolbar button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
     color: #8fa876;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2857,8 +2864,7 @@ decoration {
   margin: 10px; }
   decoration:backdrop {
     box-shadow: 0 0 0 1px rgba(29, 29, 29, 0.9), 0 8px 8px 0 transparent, 0 5px 5px 0 rgba(0, 0, 0, 0.35); }
-  .fullscreen decoration,
-  .tiled decoration {
+  .fullscreen decoration, .tiled decoration {
     border-radius: 0; }
   .popup decoration {
     box-shadow: none;
@@ -2961,42 +2967,52 @@ headerbar button.titlebutton,
   .titlebar button.titlebutton.minimize:active {
     background-image: -gtk-scaled(url("assets/titlebutton-min-active-dark.png"), url("assets/titlebutton-min-active-dark@2.png")); }
 
-.view:selected, iconview:selected, .view:selected:focus, .view text:selected, iconview text:selected,
-textview text:selected, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
-textview text selection:focus,
-textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
-modelbutton.flat:active,
-modelbutton.flat:active arrow,
-modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+.caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
 filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
 filechooser placessidebar.sidebar list row.sidebar-row:selected,
 filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
-filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .view:selected, .view:selected:focus,
+.view text:selected,
+textview text:selected,
+.view text:selected:focus,
+textview text:selected:focus, .view text selection:focus, .view text selection,
+textview text selection:focus,
+textview text selection, iconview:selected, iconview:selected:focus, iconview text selection:focus, .view text selection, iconview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+modelbutton.flat:active,
+modelbutton.flat:active arrow,
+modelbutton.flat:selected,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected {
   background-color: #8fa876; }
-  row:selected label, label:selected, .view:selected, iconview:selected, .view:selected:focus, .view text:selected, iconview text:selected,
-  textview text:selected, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
-  textview text selection:focus,
-  textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
-  modelbutton.flat:active,
-  modelbutton.flat:active arrow,
-  modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+  row:selected label, label:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
   filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
   filechooser placessidebar.sidebar list row.sidebar-row:selected,
   filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
-  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .view:selected, .view:selected:focus,
+  .view text:selected,
+  textview text:selected,
+  .view text:selected:focus,
+  textview text:selected:focus, .view text selection:focus, .view text selection,
+  textview text selection:focus,
+  textview text selection, iconview:selected, iconview:selected:focus, iconview text selection:focus, .view text selection, iconview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+  modelbutton.flat:active,
+  modelbutton.flat:active arrow,
+  modelbutton.flat:selected,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected {
     color: #ffffff; }
-    label:disabled selection, row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
-    textview text:disabled:selected, iconview text:disabled:selected:focus,
-    textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
-    textview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    label:disabled selection, row:selected label:disabled, label:disabled:selected, .caja-navigation-window .view .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected, .nemo-window .nemo-inactive-pane .view:disabled:selected:focus, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .view:disabled:selected,
+    .view text:disabled:selected,
+    textview text:disabled:selected,
+    textview text:disabled:selected:focus, .view text selection:disabled,
+    textview text selection:disabled:focus,
+    textview text selection:disabled, iconview:disabled:selected, iconview:disabled:selected:focus, iconview text selection:disabled:focus, iconview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
-    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
-    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected, .caja-navigation-window .view .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected:focus {
+    modelbutton.flat:selected arrow:disabled, row:disabled:selected {
       color: #c7d4bb; }
 
 GeditNotebook.notebook tab.reorderable-page.top:active, GeditNotebook.notebook tab.reorderable-page.top.active-page, GeditNotebook.notebook tab.reorderable-page.top.active-page:hover, GeditNotebook.notebook tab.top:active, GeditNotebook.notebook tab.top.active-page, GeditNotebook.notebook tab.top.active-page:hover,
@@ -3098,10 +3114,9 @@ vte-terminal {
     color: #ffffff; }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
-popover.background label.nautilus-canvas-item.separator,
 .nautilus-list-dim-label {
   color: #898989; }
-  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected:focus,
+  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, .nautilus-canvas-item.dim-label:selected:focus,
   .nautilus-list-dim-label:selected,
   .nautilus-list-dim-label:selected:focus {
     color: #e9eee4; }
@@ -3130,8 +3145,8 @@ filechooser placessidebar.sidebar list {
     filechooser placessidebar.sidebar list row.sidebar-row:disabled label,
     filechooser placessidebar.sidebar list row.sidebar-row:disabled image {
       color: rgba(219, 219, 219, 0.4); }
-    .nautilus-window placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
-    filechooser placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon,
+    .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon {
@@ -3246,7 +3261,8 @@ NautilusListView .view, NautilusListView iconview {
   .nemo-window grid > paned > separator {
     background-image: linear-gradient(to bottom, #353535, #353535); }
   .nemo-window widget .toolbar .image-button, .nemo-window widget .toolbar headerbar button.titlebutton, headerbar .nemo-window widget .toolbar button.titlebutton,
-  .nemo-window widget .toolbar .titlebar button.titlebutton, .titlebar .nemo-window widget .toolbar button.titlebutton {
+  .nemo-window widget .toolbar .titlebar button.titlebutton,
+  .titlebar .nemo-window widget .toolbar button.titlebutton {
     padding: 0; }
 
 .caja-navigation-window {
@@ -3254,7 +3270,7 @@ NautilusListView .view, NautilusListView iconview {
    * when split panes are used. Without it the inactive pane isn't displayed
    * properly
    */ }
-  .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+  .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus {
     background-image: linear-gradient(to bottom, #8fa876, #8fa876); }
   .caja-navigation-window .caja-side-pane .view, .caja-navigation-window .caja-side-pane iconview,
   .caja-navigation-window .caja-side-pane textview text,
@@ -3352,7 +3368,7 @@ NautilusListView .view, NautilusListView iconview {
   .gedit-map-frame border:dir(rtl) {
     border-right-width: 1px; }
 
-.gedit-search-slider, .xed-window .xed-goto-line-box {
+.xed-window .xed-goto-line-box, .gedit-search-slider {
   background-color: #3d3d3d;
   padding: 6px;
   border-color: #292929;
@@ -3432,8 +3448,7 @@ dockoverlayedge {
   dockoverlayedge docktabstrip {
     padding: 0;
     border: none; }
-  dockoverlayedge.left-edge tab:checked,
-  dockoverlayedge.right-edge tab:checked {
+  dockoverlayedge.left-edge tab:checked, dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
 
 popover.messagepopover.background {
@@ -3661,7 +3676,9 @@ SynapseGuiViewVirgilio *:selected {
     color: #ffffff;
     border: none;
     background-color: #8fa876; }
-  .gnome-panel-menu-bar button:not(#tasklist-button) label, .mate-panel-menu-bar button:not(#tasklist-button) label, .xfce4-panel.panel button label, .gnome-panel-menu-bar button:not(#tasklist-button) image, .mate-panel-menu-bar button:not(#tasklist-button) image, .xfce4-panel.panel button image {
+  .gnome-panel-menu-bar button:not(#tasklist-button) label,
+  .mate-panel-menu-bar button:not(#tasklist-button) label, .xfce4-panel.panel button label, .gnome-panel-menu-bar button:not(#tasklist-button) image,
+  .mate-panel-menu-bar button:not(#tasklist-button) image, .xfce4-panel.panel button image {
     color: inherit; }
 
 .floating-bar {
@@ -3726,8 +3743,7 @@ PantheonTerminalPantheonTerminalWindow.background {
   background-color: transparent; }
 
 SwitchboardCategoryView .view:selected, SwitchboardCategoryView iconview:selected,
-SwitchboardCategoryView .view:selected:focus,
-SwitchboardCategoryView iconview:selected:focus {
+SwitchboardCategoryView .view:selected:focus {
   color: #DADADA; }
 
 .cs-header {
@@ -3755,26 +3771,31 @@ SwitchboardCategoryView iconview:selected:focus {
   padding: 0; }
 
 EvWindow .content-view .view:selected, EvWindow .content-view iconview:selected,
-EvWindow .content-view .view:focus:selected,
-EvWindow .content-view iconview:focus:selected {
+EvWindow .content-view .view:focus:selected {
   background-color: #8fa876;
   color: #ffffff; }
 
 .nautilus-window placessidebar.sidebar list scrollbar,
 filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollbar {
   border-color: #282828; }
-  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
+  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider,
+  filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
     background-color: white;
     border: 1px solid rgba(0, 0, 0, 0.3); }
-  .nautilus-window placessidebar.sidebar list scrollbar slider, filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
+  .nautilus-window placessidebar.sidebar list scrollbar slider,
+  filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
     background-color: rgba(255, 255, 255, 0.7); }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:hover, filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover,
+    filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
       background-color: white; }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active, filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active,
+    filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
       background-color: #8fa876; }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled, filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled,
+    filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
       background-color: transparent; }
-  .nautilus-window placessidebar.sidebar list scrollbar trough, filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
+  .nautilus-window placessidebar.sidebar list scrollbar trough,
+  filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
     background-color: #282828; }
 
 .thunar .sidebar .view, .thunar .sidebar iconview {
@@ -4006,3 +4027,108 @@ window.background.lightdm .lightdm-combo {
 @define-color wm_icon_unfocused_bg #666A74;
 @define-color wm_icon_hover_bg #C4C7CC;
 @define-color wm_icon_active_bg #ffffff;
+/* Based on _Adwaita-base.scss from libhandy */
+popover.combo {
+  padding: 0; }
+  popover.combo list {
+    background-color: transparent; }
+    popover.combo list > row {
+      padding: 0 10px;
+      min-height: 50px; }
+
+row.expander {
+  padding: 0px; }
+  row.expander:checked image.expander-row-arrow:not(:disabled) {
+    color: #8fa876; }
+  row.expander image.expander-row-arrow:disabled {
+    color: rgba(218, 218, 218, 0.55); }
+
+keypad .digit {
+  font-size: 200%;
+  font-weight: bold; }
+
+keypad .letters {
+  font-size: 70%; }
+
+keypad .symbol {
+  font-size: 160%; }
+
+viewswitcher, viewswitcher button {
+  margin: 0;
+  padding: 0; }
+
+viewswitcher button {
+  border-radius: 0;
+  border-top: 0;
+  border-bottom: 0; }
+  viewswitcher button:not(:checked):not(:hover) {
+    background: transparent;
+    border-color: transparent; }
+  viewswitcher button:checked, viewswitcher button:active {
+    border-color: #8fa876; }
+  viewswitcher button > stack > box.narrow {
+    font-size: 0.75rem;
+    padding-top: 7px;
+    padding-bottom: 5px; }
+    viewswitcher button > stack > box.narrow image,
+    viewswitcher button > stack > box.narrow label {
+      padding-left: 8px;
+      padding-right: 8px; }
+  viewswitcher button > stack > box.wide {
+    padding: 8px 10px; }
+    viewswitcher button > stack > box.wide label:dir(ltr) {
+      padding-right: 7px; }
+    viewswitcher button > stack > box.wide label:dir(rtl) {
+      padding-left: 7px; }
+  viewswitcher button.needs-attention > stack > box label {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#8fa876), to(transparent));
+    background-size: 6px 6px;
+    background-repeat: no-repeat;
+    background-position: right 0px; }
+    viewswitcher button.needs-attention > stack > box label:dir(rtl) {
+      background-position: left 0px; }
+  viewswitcher button.needs-attention:active > stack > box label {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#ffffff), to(transparent)); }
+
+viewswitcherbar actionbar > revealer > box {
+  padding: 0; }
+
+list.content,
+list.content list {
+  background-color: transparent; }
+
+list.content list.nested > row:not(:active):not(:hover):not(:selected), list.content list.nested > row:not(:active):hover:not(.activatable):not(:selected) {
+  background-color: #3c3c3c; }
+
+list.content list.nested > row.activatable:not(:active):hover:not(:selected) {
+  background-color: #464646; }
+
+list.content > row:not(.expander):not(:active):not(:hover):not(:selected), list.content > row:not(.expander):not(:active):hover:not(.activatable):not(:selected), list.content > row.expander row.header:not(:active):not(:hover):not(:selected), list.content > row.expander row.header:not(:active):hover:not(.activatable):not(:selected) {
+  background-color: #404040; }
+
+list.content > row.activatable:not(.expander):not(:active):hover:not(:selected), list.content > row.expander row.header.activatable:not(:active):hover:not(:selected) {
+  background-color: #464646; }
+
+list.content > row,
+list.content > row list > row {
+  border-color: #292929;
+  border-style: solid;
+  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list.content > row:not(:last-child) {
+  border-width: 1px 1px 0px 1px; }
+
+list.content > row:last-child, list.content > row.checked-expander-row-previous-sibling, list.content > row.expander:checked {
+  border-width: 1px; }
+
+list.content > row.expander:checked:not(:first-child), list.content > row.expander:checked + row {
+  margin-top: 5px; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized),
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration,
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay {
+  border-radius: 3px; }
+
+.windowhandle separator.sidebar:dir(ltr), .windowhandle separator.sidebar.left, .windowhandle separator.sidebar.left:dir(rtl), .windowhandle separator.sidebar:dir(rtl), .windowhandle separator.sidebar.right {
+  background-color: #252525;
+  margin: 0; }

--- a/src/Mint-Y/gtk-3.0/gtk-darker.css
+++ b/src/Mint-Y/gtk-3.0/gtk-darker.css
@@ -55,7 +55,7 @@ textview text {
 textview border {
   background-color: #f8f8f8; }
 
-rubberband, flowbox rubberband, treeview.view rubberband, .content-view rubberband,
+rubberband, .content-view rubberband, treeview.view rubberband, flowbox rubberband,
 .rubberband {
   border: 1px solid #789d55;
   background-color: rgba(120, 157, 85, 0.2); }
@@ -76,8 +76,8 @@ label selection {
 label:disabled {
   color: rgba(48, 48, 48, 0.55); }
 
-.dim-label, label.separator, popover label.separator,
-popover.background label.separator {
+.dim-label, popover label.separator,
+popover.background label.separator, label.separator {
   color: rgba(48, 48, 48, 0.65); }
 
 assistant .sidebar {
@@ -102,9 +102,9 @@ textview {
   background-color: #f8f8f8;
   color: #303030; }
 
-popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
+.osd .scale-popup, popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
 popover.background.osd,
-popover.background.magnifier, .csd popover.background.osd, .csd popover.background.magnifier, .osd .scale-popup, .osd {
+popover.background.magnifier, .csd popover.background.osd, .csd popover.background.magnifier, .osd {
   color: #dbdbdb;
   border: none;
   background-color: #404040;
@@ -313,13 +313,16 @@ button {
   .titlebar button.text-button.titlebutton {
     padding-left: 5px;
     padding-right: 5px; }
-    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child, .titlebar button.text-button.titlebutton label:first-child {
+    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child,
+    .titlebar button.text-button.titlebutton label:first-child {
       padding-left: 8px;
       padding-right: 2px; }
-    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child, .titlebar button.text-button.titlebutton label:last-child {
+    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child,
+    .titlebar button.text-button.titlebutton label:last-child {
       padding-right: 8px;
       padding-left: 2px; }
-    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child, .titlebar button.text-button.titlebutton label:only-child {
+    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child,
+    .titlebar button.text-button.titlebutton label:only-child {
       padding-left: 8px;
       padding-right: 8px; }
     button.text-button.image-button.popup, headerbar button.text-button.popup.titlebutton,
@@ -391,8 +394,7 @@ button {
         outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(33, 33, 33, 0.4);
         background-color: #92b372; }
-  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
-  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
+  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child), .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
@@ -527,94 +529,70 @@ button {
     .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
       color: inherit; }
 
-toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, .linked:not(.vertical) > entry,
-.linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button,
-.linked:not(.vertical) > button:hover,
-.linked:not(.vertical) > button:active,
-.linked:not(.vertical) > button:checked, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .linked:not(.vertical).path-bar > button,
-headerbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
-.primary-toolbar .linked:not(.vertical).path-bar > button:hover,
-headerbar .linked:not(.vertical).path-bar > button:hover,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
-.primary-toolbar .linked:not(.vertical).path-bar > button:active,
-headerbar .linked:not(.vertical).path-bar > button:active,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
-.primary-toolbar .linked:not(.vertical).path-bar > button:checked,
-headerbar .linked:not(.vertical).path-bar > button:checked,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
-.primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
-headerbar .linked:not(.vertical).path-bar > button:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl) {
+.linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl),
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button,
+headerbar .linked.path-bar:not(.vertical) > button, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .linked:not(.vertical) > entry, .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button, .linked:not(.vertical) > button:hover, .linked:not(.vertical) > button:active, .linked:not(.vertical) > button:checked, toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat {
   border-radius: 0;
   border-right-style: none; }
 
-toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
-headerbar .linked:not(.vertical).path-bar > button:first-child,
-headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:first-child:active,
-headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled, .linked:not(.vertical) > combobox:first-child > box > button.combo {
+popover.combo scrollbar.vertical:dir(rtl), .linked:not(.vertical) > combobox:first-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:first-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:first-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:first-child,
+headerbar .linked.path-bar:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .inline-toolbar button:first-child:backdrop, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat {
   border-top-left-radius: 3px;
   border-bottom-left-radius: 3px;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0; }
 
-toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
-headerbar .linked:not(.vertical).path-bar > button:last-child,
-headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:last-child:active,
-headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox:last-child > box > button.combo {
+popover.combo scrollbar.vertical:dir(ltr), .linked:not(.vertical) > combobox:last-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:last-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:last-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:last-child,
+headerbar .linked.path-bar:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .inline-toolbar button:last-child:backdrop, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat {
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-right-style: solid; }
 
-toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
-headerbar .linked:not(.vertical).path-bar > button:only-child,
-headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:only-child:active,
-headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled, .linked:not(.vertical) > combobox:only-child > box > button.combo {
+.linked:not(.vertical) > combobox:only-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:only-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:only-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:only-child,
+headerbar .linked.path-bar:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .inline-toolbar button:only-child:backdrop, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat {
   border-radius: 3px;
   border-style: solid; }
 
-.linked.vertical > entry,
-.linked.vertical > entry:focus, .linked.vertical > button,
-.linked.vertical > button:hover,
-.linked.vertical > button:active,
-.linked.vertical > button:checked, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > combobox > box > button.combo {
+.linked.vertical > combobox > box > button.combo, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > entry, .linked.vertical > entry:focus, .linked.vertical > button, .linked.vertical > button:hover, .linked.vertical > button:active, .linked.vertical > button:checked {
   border-radius: 0;
   border-bottom-style: none; }
 
-.linked.vertical > entry:first-child, .linked.vertical > button:first-child, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > combobox:first-child > box > button.combo {
+list.content > row:first-child, list.content > row.expander:first-child row.header, list.content > row.expander:checked, list.content > row.expander:checked row.header, list.content > row.expander:checked + row, list.content > row.expander:checked + row.expander row.header, popover.combo overshoot.top, popover.combo list > row:first-child, .linked.vertical > combobox:first-child > box > button.combo, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > entry:first-child, .linked.vertical > button:first-child {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px; }
 
-.linked.vertical > entry:last-child, .linked.vertical > button:last-child, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > combobox:last-child > box > button.combo {
+list.content > row:last-child, list.content > row.checked-expander-row-previous-sibling, list.content > row.expander:checked, list.content > row.expander:not(:checked):last-child row.header, list.content > row.expander.checked-expander-row-previous-sibling:not(:checked) row.header, list.content > row.expander.empty:checked row.header, list.content > row.expander list.nested > row:last-child, popover.combo overshoot.bottom, popover.combo list > row:last-child, .linked.vertical > combobox:last-child > box > button.combo, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > entry:last-child, .linked.vertical > button:last-child {
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
   border-bottom-style: solid; }
 
-.linked.vertical > entry:only-child, .linked.vertical > button:only-child, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > combobox:only-child > box > button.combo {
+.linked.vertical > combobox:only-child > box > button.combo, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > entry:only-child, .linked.vertical > button:only-child {
   border-radius: 3px;
   border-style: solid; }
 
-menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, .app-notification button.flat, .app-notification button.flat:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, .app-notification button.flat:disabled, .app-notification button.flat, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.flat:hover, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, menuitem.button.flat,
+modelbutton.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -657,28 +635,21 @@ button:link, button:visited,
   button:visited,
   *:link:visited {
     color: #5294E2; }
-    *:selected button:visited, *:selected
-    *:link:visited {
+    *:selected button:visited, *:selected *:link:visited {
       color: #d3e1c7; }
   button:hover:link, button:hover:visited,
   *:link:hover {
     color: #7eafe9; }
-    *:selected button:hover:link, *:selected button:hover:visited, *:selected
-    *:link:hover {
+    *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover {
       color: #f4f7f1; }
   button:active:link, button:active:visited,
   *:link:active {
     color: #5294E2; }
-    *:selected button:active:link, *:selected button:active:visited, *:selected
-    *:link:active {
+    *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active {
       color: #e9f0e3; }
-  headerbar.selection-mode .subtitle:link,
-  .selection-mode.titlebar:not(headerbar) .subtitle:link, infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, button:selected:link, button:selected:visited,
-  *:selected button:link,
-  *:selected button:visited,
-  *:link:selected,
-  *:selected
-  *:link {
+  infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, button:selected:link, button:selected:visited, *:selected button:link, *:selected button:visited,
+  *:link:selected, *:selected *:link {
     color: #e9f0e3; }
 
 button:link > label, button:visited > label {
@@ -696,8 +667,7 @@ spinbutton:disabled {
 spinbutton:not(.vertical) entry {
   min-width: 28px; }
 
-spinbutton:not(.vertical):dir(ltr) entry,
-spinbutton:not(.vertical):dir(rtl) button.up {
+spinbutton:not(.vertical):dir(ltr) entry, spinbutton:not(.vertical):dir(rtl) button.up {
   border-radius: 3px 0 0 3px; }
 
 spinbutton:not(.vertical) > button + button {
@@ -918,28 +888,18 @@ headerbar,
         -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
     .maximized headerbar.selection-mode, .maximized .selection-mode.titlebar:not(headerbar) {
       background-color: #92b372; }
-  .tiled headerbar, .tiled headerbar:backdrop,
-  .maximized headerbar, .maximized headerbar:backdrop, .tiled .titlebar:not(headerbar), .tiled .titlebar:backdrop:not(headerbar),
-  .maximized .titlebar:not(headerbar), .maximized .titlebar:backdrop:not(headerbar) {
+  .tiled headerbar, .tiled headerbar:backdrop, .maximized headerbar, .maximized headerbar:backdrop, .tiled .titlebar:not(headerbar), .maximized .titlebar:not(headerbar) {
     border-radius: 0; }
-  .maximized headerbar,
-  .maximized .titlebar:not(headerbar) {
+  .maximized headerbar, .maximized .titlebar:not(headerbar) {
     background-color: #2f2f2f;
     border-color: #252525; }
-  headerbar.default-decoration,
-  .csd headerbar.default-decoration, headerbar.default-decoration:backdrop,
-  .csd headerbar.default-decoration:backdrop,
-  .default-decoration.titlebar:not(headerbar),
-  .csd .default-decoration.titlebar:not(headerbar),
-  .default-decoration.titlebar:backdrop:not(headerbar),
-  .csd .default-decoration.titlebar:backdrop:not(headerbar) {
+  headerbar.default-decoration, .csd headerbar.default-decoration, headerbar.default-decoration:backdrop, .csd headerbar.default-decoration:backdrop,
+  .default-decoration.titlebar:not(headerbar) {
     min-height: 28px;
     padding: 0 7px;
     background-color: #2f2f2f;
     border-bottom-width: 0; }
-    .maximized headerbar.default-decoration, .maximized
-    .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized
-    .csd headerbar.default-decoration:backdrop, .maximized .default-decoration.titlebar:not(headerbar), .maximized .csd .default-decoration.titlebar:not(headerbar), .maximized .default-decoration.titlebar:backdrop:not(headerbar), .maximized .csd .default-decoration.titlebar:backdrop:not(headerbar) {
+    .maximized headerbar.default-decoration, .maximized .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized .csd headerbar.default-decoration:backdrop, .maximized .default-decoration.titlebar:not(headerbar) {
       background-color: #2f2f2f; }
 
 .titlebar {
@@ -951,23 +911,15 @@ headerbar entry, headerbar button, headerbar separator {
 
 separator:first-child + headerbar, separator:first-child + headerbar:backdrop, headerbar:first-child, headerbar:first-child:backdrop {
   border-top-left-radius: 3px; }
-  .maximized separator:first-child + headerbar,
-  .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop,
-  .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child,
-  .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop,
-  .tiled headerbar:first-child:backdrop {
+  .maximized separator:first-child + headerbar, .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop, .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child, .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop, .tiled headerbar:first-child:backdrop {
     border-radius: 0; }
 
 headerbar:last-child, headerbar:last-child:backdrop {
   border-top-right-radius: 3px; }
-  .maximized headerbar:last-child,
-  .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop,
-  .tiled headerbar:last-child:backdrop {
+  .maximized headerbar:last-child, .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop, .tiled headerbar:last-child:backdrop {
     border-radius: 0; }
 
-window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop,
-window.csd > .titlebar:not(headerbar),
-window.csd > .titlebar:not(headerbar):backdrop {
+window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop, window.csd > .titlebar:not(headerbar), window.csd > .titlebar:not(headerbar):backdrop {
   padding: 0;
   background: none;
   border: none;
@@ -976,354 +928,434 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .titlebar:not(headerbar) > separator {
   background-image: linear-gradient(to bottom, #252525, #252525); }
 
-.primary-toolbar toolbar separator, .primary-toolbar .inline-toolbar separator,
-.primary-toolbar:not(.libreoffice-toolbar) separator {
+.primary-toolbar toolbar separator,
+.primary-toolbar:not(.libreoffice-toolbar) separator, .primary-toolbar .inline-toolbar separator {
   min-width: 1px;
   min-height: 1px;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(222, 214, 214, 0) 25%, rgba(222, 214, 214, 0.35) 25%, rgba(222, 214, 214, 0.35) 75%, rgba(222, 214, 214, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar toolbar separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop,
-  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop {
+  .primary-toolbar toolbar separator:backdrop,
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop {
     opacity: 0.6; }
 
-.primary-toolbar toolbar entry, .primary-toolbar .inline-toolbar entry, .primary-toolbar entry, headerbar entry {
+
+.primary-toolbar entry, headerbar entry {
   color: #ded6d6;
   border-color: rgba(16, 16, 16, 0.4);
   background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar entry image, .primary-toolbar .inline-toolbar entry image, .primary-toolbar entry image, headerbar entry image, .primary-toolbar toolbar entry image:hover, .primary-toolbar .inline-toolbar entry image:hover, .primary-toolbar entry image:hover, headerbar entry image:hover {
+  
+  .primary-toolbar entry image, headerbar entry image {
     color: inherit; }
-  .primary-toolbar toolbar entry:backdrop, .primary-toolbar .inline-toolbar entry:backdrop, .primary-toolbar entry:backdrop, headerbar entry:backdrop {
+  
+  .primary-toolbar entry:backdrop, headerbar entry:backdrop {
     opacity: 0.85; }
-  .primary-toolbar toolbar entry:focus, .primary-toolbar .inline-toolbar entry:focus, .primary-toolbar entry:focus, headerbar entry:focus {
+  
+  .primary-toolbar entry:focus, headerbar entry:focus {
     color: #ded6d6;
     border-color: #92b372;
     background-color: rgba(103, 103, 103, 0.4);
     background-clip: padding-box; }
-    .primary-toolbar toolbar entry:focus image, .primary-toolbar .inline-toolbar entry:focus image, .primary-toolbar entry:focus image, headerbar entry:focus image {
+    
+    .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: rgba(222, 214, 214, 0.85); }
-  .primary-toolbar toolbar entry:disabled, .primary-toolbar .inline-toolbar entry:disabled, .primary-toolbar entry:disabled, headerbar entry:disabled {
+  
+  .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(103, 103, 103, 0.25); }
-  .primary-toolbar toolbar entry selection:focus, .primary-toolbar .inline-toolbar entry selection:focus, .primary-toolbar entry selection:focus, headerbar entry selection:focus {
+  
+  .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #92b372;
     color: #ffffff; }
-  .primary-toolbar toolbar entry progress, .primary-toolbar .inline-toolbar entry progress, .primary-toolbar entry progress, headerbar entry progress {
+  
+  .primary-toolbar entry progress, headerbar entry progress {
     border-color: #92b372;
     background-image: none;
     background-color: transparent; }
-  .primary-toolbar toolbar entry.warning, .primary-toolbar .inline-toolbar entry.warning, .primary-toolbar entry.warning, headerbar entry.warning {
+  
+  .primary-toolbar entry.warning, headerbar entry.warning {
     color: white;
     border-color: rgba(16, 16, 16, 0.4);
     background-color: #a45b33; }
-    .primary-toolbar toolbar entry.warning:focus, .primary-toolbar .inline-toolbar entry.warning:focus, .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
+    
+    .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
       color: white;
       background-color: #f27835; }
-    .primary-toolbar toolbar entry.warning selection, .primary-toolbar .inline-toolbar entry.warning selection, .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar toolbar entry.warning selection:focus, .primary-toolbar .inline-toolbar entry.warning selection:focus, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
+    
+    .primary-toolbar entry.warning selection, headerbar entry.warning selection {
       background-color: white;
       color: #f27835; }
-  .primary-toolbar toolbar entry.error, .primary-toolbar .inline-toolbar entry.error, .primary-toolbar entry.error, headerbar entry.error {
+  
+  .primary-toolbar entry.error, headerbar entry.error {
     color: white;
     border-color: rgba(16, 16, 16, 0.4);
     background-color: #aa3a34; }
-    .primary-toolbar toolbar entry.error:focus, .primary-toolbar .inline-toolbar entry.error:focus, .primary-toolbar entry.error:focus, headerbar entry.error:focus {
+    
+    .primary-toolbar entry.error:focus, headerbar entry.error:focus {
       color: white;
       background-color: #FC4138; }
-    .primary-toolbar toolbar entry.error selection, .primary-toolbar .inline-toolbar entry.error selection, .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar toolbar entry.error selection:focus, .primary-toolbar .inline-toolbar entry.error selection:focus, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
+    
+    .primary-toolbar entry.error selection, headerbar entry.error selection {
       background-color: white;
       color: #FC4138; }
 
-.primary-toolbar toolbar button, .primary-toolbar .inline-toolbar button, .primary-toolbar button, headerbar button {
+
+.primary-toolbar button, headerbar button {
   color: #ded6d6;
   outline-color: rgba(222, 214, 214, 0.3);
   outline-offset: -3px;
   background-color: rgba(47, 47, 47, 0);
   border-color: rgba(47, 47, 47, 0); }
-  .primary-toolbar toolbar button:backdrop, .primary-toolbar .inline-toolbar button:backdrop, .primary-toolbar button:backdrop, headerbar button:backdrop {
+  
+  .primary-toolbar button:backdrop, headerbar button:backdrop {
     opacity: 0.7; }
-  .primary-toolbar toolbar button:hover, .primary-toolbar .inline-toolbar button:hover, .primary-toolbar button:hover, headerbar button:hover {
+  
+  .primary-toolbar button:hover, headerbar button:hover {
     color: #ded6d6;
     outline-color: rgba(222, 214, 214, 0.3);
     border-color: rgba(16, 16, 16, 0.4);
     background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar button:active, .primary-toolbar .inline-toolbar button:active, .primary-toolbar button:active, headerbar button:active, .primary-toolbar toolbar button:checked, .primary-toolbar .inline-toolbar button:checked, .primary-toolbar button:checked, headerbar button:checked {
+  
+  .primary-toolbar button:active, headerbar button:active,
+  .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #92b372;
     background-clip: padding-box; }
-  .primary-toolbar toolbar button:disabled, .primary-toolbar .inline-toolbar button:disabled, .primary-toolbar button:disabled, headerbar button:disabled {
+  
+  .primary-toolbar button:disabled, headerbar button:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button:disabled label, .primary-toolbar .inline-toolbar button:disabled label, .primary-toolbar button:disabled label, headerbar button:disabled label {
+    
+    .primary-toolbar button:disabled label, headerbar button:disabled label {
       color: inherit; }
-  .primary-toolbar toolbar button:disabled:active, .primary-toolbar .inline-toolbar button:disabled:active, .primary-toolbar button:disabled:active, headerbar button:disabled:active, .primary-toolbar toolbar button:disabled:checked, .primary-toolbar .inline-toolbar button:disabled:checked, .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
+  
+  .primary-toolbar button:disabled:active, headerbar button:disabled:active,
+  .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
     color: rgba(255, 255, 255, 0.75);
     border-color: rgba(146, 179, 114, 0.65);
     background-color: rgba(146, 179, 114, 0.65); }
 
-.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat {
+.primary-toolbar toolbar.selection-mode button,
+.selection-mode.primary-toolbar button, .primary-toolbar .selection-mode.inline-toolbar button, headerbar.selection-mode button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
 
+
 .primary-toolbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child), headerbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child) {
   margin-right: 1px; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, headerbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:active, headerbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, headerbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked:not(.vertical):not(.path-bar) > button:disabled {
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
+
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
 .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
 .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
 headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
 .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
 .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .linked:not(.vertical).path-bar > button,
-headerbar .linked:not(.vertical).path-bar > button {
+.primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button,
+headerbar .linked.path-bar:not(.vertical) > button {
   color: #ded6d6;
   outline-color: rgba(222, 214, 214, 0.3);
   border-color: rgba(16, 16, 16, 0.4);
   background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:hover,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:hover,
-  headerbar .linked:not(.vertical).path-bar > button:hover {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:hover,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:hover,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:hover,
+  headerbar .linked.path-bar:not(.vertical) > button:hover {
     background-color: rgba(141, 141, 141, 0.4); }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:active,
-  headerbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:checked,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:checked,
-  headerbar .linked:not(.vertical).path-bar > button:checked {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:active,
+  headerbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:checked,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:checked,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:checked,
+  headerbar .linked.path-bar:not(.vertical) > button:checked {
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     border-color: transparent;
     background-color: #92b372; }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:disabled,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
-  headerbar .linked:not(.vertical).path-bar > button:disabled {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  headerbar .linked.path-bar:not(.vertical) > button:disabled {
     color: rgba(222, 214, 214, 0.6); }
 
-.primary-toolbar toolbar .linked:not(.vertical) entry, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry, .primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
+
+.primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
   box-shadow: none; }
-  .primary-toolbar toolbar .linked:not(.vertical) entry:focus, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry:focus, .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
+  
+  .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
     color: #ded6d6;
     border-color: rgba(16, 16, 16, 0.4);
     background-color: rgba(103, 103, 103, 0.4);
     background-clip: padding-box; }
-    .primary-toolbar toolbar .linked:not(.vertical) entry:focus image, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry:focus image, .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image, .primary-toolbar .linked:not(.vertical) entry:focus image:hover, headerbar .linked:not(.vertical) entry:focus image:hover {
+    
+    .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image {
       color: inherit; }
-  .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
+  
+  .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
     color: #ded6d6;
     outline-color: rgba(222, 214, 214, 0.3);
     border-color: rgba(16, 16, 16, 0.4);
     background-color: rgba(103, 103, 103, 0.4); }
+    
     .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover {
       background-color: rgba(141, 141, 141, 0.4); }
-    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
+    
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active,
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
       color: #ffffff;
       outline-color: rgba(255, 255, 255, 0.3);
       border-color: transparent;
       background-color: #92b372; }
+    
     .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
       color: rgba(222, 214, 214, 0.6);
       background-color: rgba(103, 103, 103, 0.2);
       border-color: rgba(16, 16, 16, 0.4); }
+      
       .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled:checked, headerbar .linked:not(.vertical) entry + button:last-child:disabled:checked {
         background-color: rgba(146, 179, 114, 0.65);
         color: rgba(255, 255, 255, 0.75); }
 
-.primary-toolbar toolbar button.suggested-action, .primary-toolbar .inline-toolbar button.suggested-action, .primary-toolbar button.suggested-action, headerbar button.suggested-action {
+
+.primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
   color: #ffffff;
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #6db442;
   border-color: #6db442; }
-  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
+  
+  .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     color: #6db442;
     outline-color: rgba(109, 180, 66, 0.3); }
-  .primary-toolbar toolbar button.suggested-action:hover, .primary-toolbar .inline-toolbar button.suggested-action:hover, .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
+  
+  .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #88c663;
     border-color: #88c663; }
-  .primary-toolbar toolbar button.suggested-action:active, .primary-toolbar .inline-toolbar button.suggested-action:active, .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar toolbar button.suggested-action:checked, .primary-toolbar .inline-toolbar button.suggested-action:checked, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
+  
+  .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active,
+  .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #568f34;
     border-color: #568f34; }
-  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+  
+  .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+    
+    .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
       color: inherit; }
 
-.primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop, .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
+
+.primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
   opacity: 0.8; }
 
-.primary-toolbar toolbar button.destructive-action, .primary-toolbar .inline-toolbar button.destructive-action, .primary-toolbar button.destructive-action, headerbar button.destructive-action {
+
+.primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
   color: #ffffff;
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #F04A50;
   border-color: #F04A50; }
-  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
+  
+  .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     color: #F04A50;
     outline-color: rgba(240, 74, 80, 0.3); }
-  .primary-toolbar toolbar button.destructive-action:hover, .primary-toolbar .inline-toolbar button.destructive-action:hover, .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
+  
+  .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #f4797e;
     border-color: #f4797e; }
-  .primary-toolbar toolbar button.destructive-action:active, .primary-toolbar .inline-toolbar button.destructive-action:active, .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar toolbar button.destructive-action:checked, .primary-toolbar .inline-toolbar button.destructive-action:checked, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
+  
+  .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active,
+  .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #ec1b22;
     border-color: #ec1b22; }
-  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+  
+  .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(47, 47, 47, 0);
     border-color: rgba(47, 47, 47, 0); }
-    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+    
+    .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
       color: inherit; }
 
-.primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop, .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
+
+.primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
   opacity: 0.8; }
 
-.primary-toolbar toolbar spinbutton:focus button, .primary-toolbar .inline-toolbar spinbutton:focus button, .primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
+
+.primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
   color: #ffffff; }
-  .primary-toolbar toolbar spinbutton:focus button:hover, .primary-toolbar .inline-toolbar spinbutton:focus button:hover, .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
+  
+  .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
     background-color: rgba(255, 255, 255, 0.1);
     border-color: transparent; }
-  .primary-toolbar toolbar spinbutton:focus button:disabled, .primary-toolbar .inline-toolbar spinbutton:focus button:disabled, .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
+  
+  .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
     color: rgba(255, 255, 255, 0.4); }
 
-.primary-toolbar toolbar spinbutton button, .primary-toolbar .inline-toolbar spinbutton button, .primary-toolbar spinbutton button, headerbar spinbutton button {
+
+.primary-toolbar spinbutton button, headerbar spinbutton button {
   color: #ded6d6; }
-  .primary-toolbar toolbar spinbutton button:hover, .primary-toolbar .inline-toolbar spinbutton button:hover, .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
+  
+  .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
     background-color: rgba(222, 214, 214, 0.25);
     border-color: transparent; }
-  .primary-toolbar toolbar spinbutton button:disabled, .primary-toolbar .inline-toolbar spinbutton button:disabled, .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
+  
+  .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
     color: rgba(222, 214, 214, 0.7); }
-  .primary-toolbar toolbar spinbutton button:active, .primary-toolbar .inline-toolbar spinbutton button:active, .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
+  
+  .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
     background-color: rgba(0, 0, 0, 0.1); }
 
-.primary-toolbar toolbar combobox:disabled, .primary-toolbar .inline-toolbar combobox:disabled, .primary-toolbar combobox:disabled, headerbar combobox:disabled {
+
+.primary-toolbar combobox:disabled, headerbar combobox:disabled {
   color: rgba(222, 214, 214, 0.4); }
 
-.primary-toolbar toolbar combobox > .linked > button.combo, .primary-toolbar .inline-toolbar combobox > .linked > button.combo, .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
+
+.primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: #ded6d6;
   border-color: rgba(16, 16, 16, 0.4);
   background-color: rgba(103, 103, 103, 0.4); }
-  .primary-toolbar toolbar combobox > .linked > button.combo image, .primary-toolbar .inline-toolbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar toolbar combobox > .linked > button.combo image:hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo image:hover, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
+  
+  .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image {
     color: inherit; }
-  .primary-toolbar toolbar combobox > .linked > button.combo:hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:hover, .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
+  
+  .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #ded6d6;
     border-color: #92b372;
     background-color: rgba(103, 103, 103, 0.4);
     box-shadow: none; }
-  .primary-toolbar toolbar combobox > .linked > button.combo:disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:disabled, .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
+  
+  .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(222, 214, 214, 0.55);
     background-color: rgba(103, 103, 103, 0.25); }
 
-.primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr), .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr), .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
+
+.primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
     box-shadow: none; }
 
-.primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl), .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl), .primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
+
+.primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
   border-left-style: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
     box-shadow: none; }
 
-.primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar combobox > .linked > button.combo:dir(ltr):hover, headerbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar combobox > .linked > button.combo:dir(ltr):active, headerbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar combobox > .linked > button.combo:dir(ltr):checked, headerbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):disabled, .primary-toolbar combobox > .linked > button.combo:dir(ltr):disabled, headerbar combobox > .linked > button.combo:dir(ltr):disabled {
+
+.primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr) {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0; }
 
-.primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar combobox > .linked > button.combo:dir(rtl):hover, headerbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar combobox > .linked > button.combo:dir(rtl):active, headerbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar combobox > .linked > button.combo:dir(rtl):checked, headerbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):disabled, .primary-toolbar combobox > .linked > button.combo:dir(rtl):disabled, headerbar combobox > .linked > button.combo:dir(rtl):disabled {
+
+.primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0; }
 
-.primary-toolbar toolbar switch:backdrop, .primary-toolbar .inline-toolbar switch:backdrop, .primary-toolbar switch:backdrop, headerbar switch:backdrop {
+
+.primary-toolbar switch:backdrop, headerbar switch:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar progressbar trough, .primary-toolbar .inline-toolbar progressbar trough, .primary-toolbar progressbar trough, headerbar progressbar trough {
+
+.primary-toolbar progressbar trough, headerbar progressbar trough {
   background-color: rgba(16, 16, 16, 0.4); }
 
-.primary-toolbar toolbar progressbar:backdrop, .primary-toolbar .inline-toolbar progressbar:backdrop, .primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
+
+.primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar scale:backdrop, .primary-toolbar .inline-toolbar scale:backdrop, .primary-toolbar scale:backdrop, headerbar scale:backdrop {
+
+.primary-toolbar scale:backdrop, headerbar scale:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar scale slider, .primary-toolbar .inline-toolbar scale slider, .primary-toolbar scale slider, headerbar scale slider {
+
+.primary-toolbar scale slider, headerbar scale slider {
   background-color: #494949;
   border-color: rgba(16, 16, 16, 0.7); }
-  .primary-toolbar toolbar scale slider:hover, .primary-toolbar .inline-toolbar scale slider:hover, .primary-toolbar scale slider:hover, headerbar scale slider:hover {
+  
+  .primary-toolbar scale slider:hover, headerbar scale slider:hover {
     background-color: #555555;
     border-color: rgba(16, 16, 16, 0.7); }
-  .primary-toolbar toolbar scale slider:active, .primary-toolbar .inline-toolbar scale slider:active, .primary-toolbar scale slider:active, headerbar scale slider:active {
+  
+  .primary-toolbar scale slider:active, headerbar scale slider:active {
     background-color: #92b372;
     border-color: #92b372; }
-  .primary-toolbar toolbar scale slider:disabled, .primary-toolbar .inline-toolbar scale slider:disabled, .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
+  
+  .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
     background-color: #414141;
     border-color: rgba(16, 16, 16, 0.7); }
 
-.primary-toolbar toolbar scale trough, .primary-toolbar .inline-toolbar scale trough, .primary-toolbar scale trough, headerbar scale trough {
+
+.primary-toolbar scale trough, headerbar scale trough {
   background-color: rgba(16, 16, 16, 0.4); }
-  .primary-toolbar toolbar scale trough:disabled, .primary-toolbar .inline-toolbar scale trough:disabled, .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
+  
+  .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
     background-color: rgba(16, 16, 16, 0.3); }
 
 .path-bar button.text-button, .path-bar button.image-button, .path-bar headerbar button.titlebutton, headerbar .path-bar button.titlebutton,
-.path-bar .titlebar button.titlebutton, .titlebar .path-bar button.titlebutton, .path-bar button {
+.path-bar .titlebar button.titlebutton,
+.titlebar .path-bar button.titlebutton, .path-bar button {
   padding-left: 6px;
   padding-right: 6px; }
 
-.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label, .path-bar .titlebar button.text-button.titlebutton label, .titlebar .path-bar button.text-button.titlebutton label {
+.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label,
+.path-bar .titlebar button.text-button.titlebutton label,
+.titlebar .path-bar button.text-button.titlebutton label {
   padding-left: 0;
   padding-right: 0; }
 
-.path-bar button.text-button.image-button label:last-child, .path-bar headerbar button.text-button.titlebutton label:last-child, headerbar .path-bar button.text-button.titlebutton label:last-child, .path-bar .titlebar button.text-button.titlebutton label:last-child, .titlebar .path-bar button.text-button.titlebutton label:last-child, .path-bar button label:last-child {
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child {
   padding-right: 10px; }
 
-.path-bar button.text-button.image-button label:first-child, .path-bar headerbar button.text-button.titlebutton label:first-child, headerbar .path-bar button.text-button.titlebutton label:first-child, .path-bar .titlebar button.text-button.titlebutton label:first-child, .titlebar .path-bar button.text-button.titlebutton label:first-child, .path-bar button label:first-child {
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child {
   padding-left: 10px; }
 
 .path-bar button.slider-button, .path-bar button:not(.image-button):not(.text-button) {
@@ -1361,9 +1393,9 @@ treeview.view {
     border-style: solid none;
     border-width: 1px;
     border-color: #617251; }
-    treeview.view:drop(active).after {
+    treeview.view.after:drop(active) {
       border-top-style: none; }
-    treeview.view:drop(active).before {
+    treeview.view.before:drop(active) {
       border-bottom-style: none; }
   treeview.view.expander {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
@@ -1456,23 +1488,16 @@ menu,
   border-radius: 0;
   background-color: #ffffff;
   border: 1px solid #BDBDBD; }
-  .csd menu, .csd
-  .menu {
+  .csd menu, .csd .menu {
     padding: 4px 0px;
     border-radius: 2px;
     border: none; }
-  menu separator,
-  .csd menu separator,
-  .menu separator,
-  .csd
-  .menu separator {
+  menu separator, .csd menu separator,
+  .menu separator, .csd .menu separator {
     margin: 2px 0;
     background-color: #DFDFDF; }
-  menu .separator:not(label),
-  .csd menu .separator:not(label),
-  .menu .separator:not(label),
-  .csd
-  .menu .separator:not(label) {
+  menu .separator:not(label), .csd menu .separator:not(label),
+  .menu .separator:not(label), .csd .menu .separator:not(label) {
     color: #ffffff; }
   menu menuitem,
   .menu menuitem {
@@ -1548,8 +1573,7 @@ popover.background {
   background-clip: border-box;
   background-color: #ffffff;
   box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.07); }
-  .csd popover, popover, .csd
-  popover.background,
+  .csd popover, popover, .csd popover.background,
   popover.background {
     border: 1px solid #b0b0b0; }
   popover separator,
@@ -1765,10 +1789,10 @@ scrollbar {
       min-height: 4px;
       background-color: #6a6a6a;
       border: 1px solid rgba(255, 255, 255, 0.6); }
-    scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider {
+    scrollbar.overlay-indicator.vertical:not(.dragging):not(.hovering) slider {
       margin: 2px 0;
       min-height: 40px; }
-    scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider {
+    scrollbar.overlay-indicator.horizontal:not(.dragging):not(.hovering) slider {
       margin: 0 2px;
       min-width: 40px; }
   scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering {
@@ -1804,8 +1828,7 @@ infobar switch {
 
 headerbar switch,
 .primary-toolbar switch,
-.primary-toolbar toolbar switch,
-.primary-toolbar .inline-toolbar switch {
+.primary-toolbar toolbar switch {
   background-image: -gtk-scaled(url("assets/switch-header-dark.png"), url("assets/switch-header-dark@2.png")); }
 
 switch:checked {
@@ -1818,8 +1841,7 @@ infobar switch:checked {
 
 headerbar switch:checked,
 .primary-toolbar switch:checked,
-.primary-toolbar toolbar switch:checked,
-.primary-toolbar .inline-toolbar switch:checked {
+.primary-toolbar toolbar switch:checked {
   background-image: -gtk-scaled(url("assets/switch-active-header-dark.png"), url("assets/switch-active-header-dark@2.png")); }
 
 switch:disabled {
@@ -1832,8 +1854,7 @@ infobar switch:disabled {
 
 headerbar switch:disabled,
 .primary-toolbar switch:disabled,
-.primary-toolbar toolbar switch:disabled,
-.primary-toolbar .inline-toolbar switch:disabled {
+.primary-toolbar toolbar switch:disabled {
   background-image: -gtk-scaled(url("assets/switch-insensitive-header-dark.png"), url("assets/switch-insensitive-header-dark@2.png")); }
 
 switch:checked:disabled {
@@ -1846,8 +1867,7 @@ infobar switch:checked:disabled {
 
 headerbar switch:checked:disabled,
 .primary-toolbar switch:checked:disabled,
-.primary-toolbar toolbar switch:checked:disabled,
-.primary-toolbar .inline-toolbar switch:checked:disabled {
+.primary-toolbar toolbar switch:checked:disabled {
   background-image: -gtk-scaled(url("assets/switch-active-insensitive-header-dark.png"), url("assets/switch-active-insensitive-header-dark@2.png")); }
 
 .check,
@@ -2065,11 +2085,8 @@ radio {
   min-width: 16px;
   min-height: 16px;
   margin: 0 2px; }
-  check:only-child,
-  menu menuitem check,
-  radio:only-child,
-  menu menuitem
-  radio {
+  check:only-child, menu menuitem check,
+  radio:only-child, menu menuitem radio {
     margin: 0; }
 
 scale {
@@ -2115,24 +2132,16 @@ scale {
       .osd scale slider:active {
         background-color: #789d55;
         border-color: #789d55; }
-    menuitem:hover scale slider,
-    row:selected scale slider,
-    infobar scale slider {
+    menuitem:hover scale slider, row:selected scale slider, infobar scale slider {
       background-color: #ffffff;
       border-color: #ffffff; }
-      menuitem:hover scale slider:hover,
-      row:selected scale slider:hover,
-      infobar scale slider:hover {
+      menuitem:hover scale slider:hover, row:selected scale slider:hover, infobar scale slider:hover {
         background-color: #eff4ea;
         border-color: #eff4ea; }
-      menuitem:hover scale slider:active,
-      row:selected scale slider:active,
-      infobar scale slider:active {
+      menuitem:hover scale slider:active, row:selected scale slider:active, infobar scale slider:active {
         background-color: #c9d9b9;
         border-color: #c9d9b9; }
-      menuitem:hover scale slider:disabled,
-      row:selected scale slider:disabled,
-      infobar scale slider:disabled {
+      menuitem:hover scale slider:disabled, row:selected scale slider:disabled, infobar scale slider:disabled {
         background-color: #ceddc0;
         border-color: #ceddc0; }
   scale trough {
@@ -2147,17 +2156,13 @@ scale {
       outline-color: rgba(219, 219, 219, 0.2); }
       .osd scale trough highlight {
         background-color: #92b372; }
-    menuitem:hover scale trough row:selected scale trough,
-    infobar scale trough {
+    menuitem:hover scale trough row:selected scale trough, infobar scale trough {
       background-color: rgba(0, 0, 0, 0.2); }
-      menuitem:hover scale trough row:selected scale trough highlight,
-      infobar scale trough highlight {
+      menuitem:hover scale trough row:selected scale trough highlight, infobar scale trough highlight {
         background-color: #ffffff; }
-        menuitem:hover scale trough row:selected scale trough highlight:disabled,
-        infobar scale trough highlight:disabled {
+        menuitem:hover scale trough row:selected scale trough highlight:disabled, infobar scale trough highlight:disabled {
           background-color: #ceddc0; }
-      menuitem:hover scale trough row:selected scale trough:disabled,
-      infobar scale trough:disabled {
+      menuitem:hover scale trough row:selected scale trough:disabled, infobar scale trough:disabled {
         background-color: rgba(0, 0, 0, 0.1); }
   scale highlight {
     border-radius: 2.5px;
@@ -2224,15 +2229,13 @@ progressbar {
     background-color: #92b372;
     border-radius: 0px;
     box-shadow: none; }
-    row:selected progressbar progress,
-    infobar progressbar progress {
+    row:selected progressbar progress, infobar progressbar progress {
       background-color: #ffffff; }
   progressbar trough {
     border: 1px solid #BDBDBD;
     border-radius: 2px;
     background-color: #ffffff; }
-    row:selected progressbar trough,
-    infobar progressbar trough {
+    row:selected progressbar trough, infobar progressbar trough {
       background-color: rgba(0, 0, 0, 0.2); }
 
 .osd .progressbar {
@@ -2404,7 +2407,7 @@ row.activatable:disabled {
 row.activatable:selected:active {
   color: #ffffff; }
 
-row.activatable:selected.has-open-popup, row.activatable:selected:hover {
+row.activatable.has-open-popup:selected, row.activatable:selected:hover {
   background-color: #83a167; }
 
 .app-notification {
@@ -2525,13 +2528,10 @@ filechooserbutton:drop(active) {
 .sidebar {
   border-style: none;
   background-color: whitesmoke; }
-  stacksidebar.sidebar:dir(ltr) list,
-  stacksidebar.sidebar.left list,
-  stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left, .sidebar.left:dir(rtl) {
+  stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left {
     border-right: 1px solid #BDBDBD;
     border-left-style: none; }
-  stacksidebar.sidebar:dir(rtl) list,
-  stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
+  stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
     border-left: 1px solid #BDBDBD;
     border-right-style: none; }
   .sidebar list {
@@ -2549,7 +2549,7 @@ stacksidebar row {
     background-size: 70px;
     background-position: 4px;
     background-repeat: no-repeat; }
-  stacksidebar row.activatable:selected.needs-attention {
+  stacksidebar row.activatable.needs-attention:selected {
     background-image: radial-gradient(circle closest-side at 5% 25%, #ffffff 0%, #ffffff 100%, transparent 100%);
     background-size: 70px;
     background-position: 4px;
@@ -2668,7 +2668,8 @@ infobar {
   infobar.question {
     background-color: #55c1ec; }
 
-.primary-toolbar toolbar.selection-mode button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover, .selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
+.primary-toolbar toolbar.selection-mode button:hover,
+.selection-mode.primary-toolbar button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
@@ -2679,7 +2680,9 @@ row:selected button.flat, infobar.info button.flat, infobar.question button.flat
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
+  .primary-toolbar toolbar.selection-mode button:disabled,
+  .selection-mode.primary-toolbar button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label,
+  .selection-mode.primary-toolbar button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
 row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
@@ -2687,7 +2690,9 @@ row:selected button:hover, infobar.info button:hover, infobar.question button:ho
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+.primary-toolbar toolbar.selection-mode button:active,
+.selection-mode.primary-toolbar button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked,
+.selection-mode.primary-toolbar button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
   color: #92b372;
   background-color: #ffffff;
   border-color: #ffffff; }
@@ -2697,7 +2702,9 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
   border-color: rgba(255, 255, 255, 0.4); }
   row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+  .primary-toolbar toolbar.selection-mode button:disabled:checked,
+  .selection-mode.primary-toolbar button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active,
+  .selection-mode.primary-toolbar button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
     color: #92b372;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2856,8 +2863,7 @@ decoration {
   margin: 10px; }
   decoration:backdrop {
     box-shadow: 0 0 0 1px rgba(29, 29, 29, 0.9), 0 8px 8px 0 transparent, 0 5px 5px 0 rgba(0, 0, 0, 0.25); }
-  .fullscreen decoration,
-  .tiled decoration {
+  .fullscreen decoration, .tiled decoration {
     border-radius: 0; }
   .popup decoration {
     box-shadow: none;
@@ -2960,42 +2966,52 @@ headerbar button.titlebutton,
   .titlebar button.titlebutton.minimize:active {
     background-image: -gtk-scaled(url("assets/titlebutton-min-active-dark.png"), url("assets/titlebutton-min-active-dark@2.png")); }
 
-.view:selected, iconview:selected, .view:selected:focus, .view text:selected, iconview text:selected,
-textview text:selected, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
-textview text selection:focus,
-textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
-modelbutton.flat:active,
-modelbutton.flat:active arrow,
-modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+.caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
 filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
 filechooser placessidebar.sidebar list row.sidebar-row:selected,
 filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
-filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .view:selected, .view:selected:focus,
+.view text:selected,
+textview text:selected,
+.view text:selected:focus,
+textview text:selected:focus, .view text selection:focus, .view text selection,
+textview text selection:focus,
+textview text selection, iconview:selected, iconview:selected:focus, iconview text selection:focus, .view text selection, iconview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+modelbutton.flat:active,
+modelbutton.flat:active arrow,
+modelbutton.flat:selected,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected {
   background-color: #92b372; }
-  row:selected label, label:selected, .view:selected, iconview:selected, .view:selected:focus, .view text:selected, iconview text:selected,
-  textview text:selected, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
-  textview text selection:focus,
-  textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
-  modelbutton.flat:active,
-  modelbutton.flat:active arrow,
-  modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+  row:selected label, label:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
   filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
   filechooser placessidebar.sidebar list row.sidebar-row:selected,
   filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
-  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .view:selected, .view:selected:focus,
+  .view text:selected,
+  textview text:selected,
+  .view text:selected:focus,
+  textview text:selected:focus, .view text selection:focus, .view text selection,
+  textview text selection:focus,
+  textview text selection, iconview:selected, iconview:selected:focus, iconview text selection:focus, .view text selection, iconview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+  modelbutton.flat:active,
+  modelbutton.flat:active arrow,
+  modelbutton.flat:selected,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected {
     color: #ffffff; }
-    label:disabled selection, row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
-    textview text:disabled:selected, iconview text:disabled:selected:focus,
-    textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
-    textview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    label:disabled selection, row:selected label:disabled, label:disabled:selected, .caja-navigation-window .view .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected, .nemo-window .nemo-inactive-pane .view:disabled:selected:focus, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .view:disabled:selected,
+    .view text:disabled:selected,
+    textview text:disabled:selected,
+    textview text:disabled:selected:focus, .view text selection:disabled,
+    textview text selection:disabled:focus,
+    textview text selection:disabled, iconview:disabled:selected, iconview:disabled:selected:focus, iconview text selection:disabled:focus, iconview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
-    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
-    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected, .caja-navigation-window .view .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected:focus {
+    modelbutton.flat:selected arrow:disabled, row:disabled:selected {
       color: #c9d9b9; }
 
 GeditNotebook.notebook tab.reorderable-page.top:active, GeditNotebook.notebook tab.reorderable-page.top.active-page, GeditNotebook.notebook tab.reorderable-page.top.active-page:hover, GeditNotebook.notebook tab.top:active, GeditNotebook.notebook tab.top.active-page, GeditNotebook.notebook tab.top.active-page:hover,
@@ -3097,10 +3113,9 @@ vte-terminal {
     color: #ffffff; }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
-popover.background label.nautilus-canvas-item.separator,
 .nautilus-list-dim-label {
   color: #909090; }
-  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected:focus,
+  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, .nautilus-canvas-item.dim-label:selected:focus,
   .nautilus-list-dim-label:selected,
   .nautilus-list-dim-label:selected:focus {
     color: #e9f0e3; }
@@ -3133,8 +3148,8 @@ filechooser placessidebar.sidebar list {
     filechooser placessidebar.sidebar list row.sidebar-row:disabled label,
     filechooser placessidebar.sidebar list row.sidebar-row:disabled image {
       color: rgba(219, 219, 219, 0.4); }
-    .nautilus-window placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
-    filechooser placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon,
+    .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon {
@@ -3248,7 +3263,8 @@ NautilusListView .view, NautilusListView iconview {
   .nemo-window grid > paned > separator {
     background-image: linear-gradient(to bottom, #404040, #404040); }
   .nemo-window widget .toolbar .image-button, .nemo-window widget .toolbar headerbar button.titlebutton, headerbar .nemo-window widget .toolbar button.titlebutton,
-  .nemo-window widget .toolbar .titlebar button.titlebutton, .titlebar .nemo-window widget .toolbar button.titlebutton {
+  .nemo-window widget .toolbar .titlebar button.titlebutton,
+  .titlebar .nemo-window widget .toolbar button.titlebutton {
     padding: 0; }
 
 .caja-navigation-window {
@@ -3256,7 +3272,7 @@ NautilusListView .view, NautilusListView iconview {
    * when split panes are used. Without it the inactive pane isn't displayed
    * properly
    */ }
-  .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+  .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus {
     background-image: linear-gradient(to bottom, #92b372, #92b372); }
   .caja-navigation-window .caja-side-pane .view, .caja-navigation-window .caja-side-pane iconview,
   .caja-navigation-window .caja-side-pane textview text,
@@ -3355,7 +3371,7 @@ NautilusListView .view, NautilusListView iconview {
   .gedit-map-frame border:dir(rtl) {
     border-right-width: 1px; }
 
-.gedit-search-slider, .xed-window .xed-goto-line-box {
+.xed-window .xed-goto-line-box, .gedit-search-slider {
   background-color: whitesmoke;
   padding: 6px;
   border-color: #BDBDBD;
@@ -3435,8 +3451,7 @@ dockoverlayedge {
   dockoverlayedge docktabstrip {
     padding: 0;
     border: none; }
-  dockoverlayedge.left-edge tab:checked,
-  dockoverlayedge.right-edge tab:checked {
+  dockoverlayedge.left-edge tab:checked, dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
 
 popover.messagepopover.background {
@@ -3664,7 +3679,9 @@ SynapseGuiViewVirgilio *:selected {
     color: #ffffff;
     border: none;
     background-color: #92b372; }
-  .gnome-panel-menu-bar button:not(#tasklist-button) label, .mate-panel-menu-bar button:not(#tasklist-button) label, .xfce4-panel.panel button label, .gnome-panel-menu-bar button:not(#tasklist-button) image, .mate-panel-menu-bar button:not(#tasklist-button) image, .xfce4-panel.panel button image {
+  .gnome-panel-menu-bar button:not(#tasklist-button) label,
+  .mate-panel-menu-bar button:not(#tasklist-button) label, .xfce4-panel.panel button label, .gnome-panel-menu-bar button:not(#tasklist-button) image,
+  .mate-panel-menu-bar button:not(#tasklist-button) image, .xfce4-panel.panel button image {
     color: inherit; }
 
 .floating-bar {
@@ -3729,8 +3746,7 @@ PantheonTerminalPantheonTerminalWindow.background {
   background-color: transparent; }
 
 SwitchboardCategoryView .view:selected, SwitchboardCategoryView iconview:selected,
-SwitchboardCategoryView .view:selected:focus,
-SwitchboardCategoryView iconview:selected:focus {
+SwitchboardCategoryView .view:selected:focus {
   color: #303030; }
 
 .cs-header {
@@ -3758,26 +3774,31 @@ SwitchboardCategoryView iconview:selected:focus {
   padding: 0; }
 
 EvWindow .content-view .view:selected, EvWindow .content-view iconview:selected,
-EvWindow .content-view .view:focus:selected,
-EvWindow .content-view iconview:focus:selected {
+EvWindow .content-view .view:focus:selected {
   background-color: #92b372;
   color: #ffffff; }
 
 .nautilus-window placessidebar.sidebar list scrollbar,
 filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollbar {
   border-color: #333333; }
-  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
+  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider,
+  filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
     background-color: white;
     border: 1px solid rgba(0, 0, 0, 0.3); }
-  .nautilus-window placessidebar.sidebar list scrollbar slider, filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
+  .nautilus-window placessidebar.sidebar list scrollbar slider,
+  filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
     background-color: rgba(255, 255, 255, 0.7); }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:hover, filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover,
+    filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
       background-color: white; }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active, filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active,
+    filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
       background-color: #92b372; }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled, filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled,
+    filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
       background-color: transparent; }
-  .nautilus-window placessidebar.sidebar list scrollbar trough, filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
+  .nautilus-window placessidebar.sidebar list scrollbar trough,
+  filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
     background-color: #333333; }
 
 .thunar .sidebar .view, .thunar .sidebar iconview {
@@ -4009,3 +4030,108 @@ window.background.lightdm .lightdm-combo {
 @define-color wm_icon_unfocused_bg #666A74;
 @define-color wm_icon_hover_bg #C4C7CC;
 @define-color wm_icon_active_bg #ffffff;
+/* Based on _Adwaita-base.scss from libhandy */
+popover.combo {
+  padding: 0; }
+  popover.combo list {
+    background-color: transparent; }
+    popover.combo list > row {
+      padding: 0 10px;
+      min-height: 50px; }
+
+row.expander {
+  padding: 0px; }
+  row.expander:checked image.expander-row-arrow:not(:disabled) {
+    color: #92b372; }
+  row.expander image.expander-row-arrow:disabled {
+    color: rgba(48, 48, 48, 0.55); }
+
+keypad .digit {
+  font-size: 200%;
+  font-weight: bold; }
+
+keypad .letters {
+  font-size: 70%; }
+
+keypad .symbol {
+  font-size: 160%; }
+
+viewswitcher, viewswitcher button {
+  margin: 0;
+  padding: 0; }
+
+viewswitcher button {
+  border-radius: 0;
+  border-top: 0;
+  border-bottom: 0; }
+  viewswitcher button:not(:checked):not(:hover) {
+    background: transparent;
+    border-color: transparent; }
+  viewswitcher button:checked, viewswitcher button:active {
+    border-color: #92b372; }
+  viewswitcher button > stack > box.narrow {
+    font-size: 0.75rem;
+    padding-top: 7px;
+    padding-bottom: 5px; }
+    viewswitcher button > stack > box.narrow image,
+    viewswitcher button > stack > box.narrow label {
+      padding-left: 8px;
+      padding-right: 8px; }
+  viewswitcher button > stack > box.wide {
+    padding: 8px 10px; }
+    viewswitcher button > stack > box.wide label:dir(ltr) {
+      padding-right: 7px; }
+    viewswitcher button > stack > box.wide label:dir(rtl) {
+      padding-left: 7px; }
+  viewswitcher button.needs-attention > stack > box label {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#92b372), to(transparent));
+    background-size: 6px 6px;
+    background-repeat: no-repeat;
+    background-position: right 0px; }
+    viewswitcher button.needs-attention > stack > box label:dir(rtl) {
+      background-position: left 0px; }
+  viewswitcher button.needs-attention:active > stack > box label {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#ffffff), to(transparent)); }
+
+viewswitcherbar actionbar > revealer > box {
+  padding: 0; }
+
+list.content,
+list.content list {
+  background-color: transparent; }
+
+list.content list.nested > row:not(:active):not(:hover):not(:selected), list.content list.nested > row:not(:active):hover:not(.activatable):not(:selected) {
+  background-color: #f8f8f8; }
+
+list.content list.nested > row.activatable:not(:active):hover:not(:selected) {
+  background-color: #f2f2f2; }
+
+list.content > row:not(.expander):not(:active):not(:hover):not(:selected), list.content > row:not(.expander):not(:active):hover:not(.activatable):not(:selected), list.content > row.expander row.header:not(:active):not(:hover):not(:selected), list.content > row.expander row.header:not(:active):hover:not(.activatable):not(:selected) {
+  background-color: #ffffff; }
+
+list.content > row.activatable:not(.expander):not(:active):hover:not(:selected), list.content > row.expander row.header.activatable:not(:active):hover:not(:selected) {
+  background-color: #f2f2f2; }
+
+list.content > row,
+list.content > row list > row {
+  border-color: #BDBDBD;
+  border-style: solid;
+  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list.content > row:not(:last-child) {
+  border-width: 1px 1px 0px 1px; }
+
+list.content > row:last-child, list.content > row.checked-expander-row-previous-sibling, list.content > row.expander:checked {
+  border-width: 1px; }
+
+list.content > row.expander:checked:not(:first-child), list.content > row.expander:checked + row {
+  margin-top: 5px; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized),
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration,
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay {
+  border-radius: 3px; }
+
+.windowhandle separator.sidebar:dir(ltr), .windowhandle separator.sidebar.left, .windowhandle separator.sidebar.left:dir(rtl), .windowhandle separator.sidebar:dir(rtl), .windowhandle separator.sidebar.right {
+  background-color: #252525;
+  margin: 0; }

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -55,7 +55,7 @@ textview text {
 textview border {
   background-color: #f8f8f8; }
 
-rubberband, flowbox rubberband, treeview.view rubberband, .content-view rubberband,
+rubberband, .content-view rubberband, treeview.view rubberband, flowbox rubberband,
 .rubberband {
   border: 1px solid #789d55;
   background-color: rgba(120, 157, 85, 0.2); }
@@ -76,8 +76,8 @@ label selection {
 label:disabled {
   color: rgba(48, 48, 48, 0.55); }
 
-.dim-label, label.separator, popover label.separator,
-popover.background label.separator {
+.dim-label, popover label.separator,
+popover.background label.separator, label.separator {
   color: rgba(48, 48, 48, 0.65); }
 
 assistant .sidebar {
@@ -102,9 +102,9 @@ textview {
   background-color: #f8f8f8;
   color: #303030; }
 
-popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
+.osd .scale-popup, popover.osd, popover.magnifier, .csd popover.osd, .csd popover.magnifier,
 popover.background.osd,
-popover.background.magnifier, .csd popover.background.osd, .csd popover.background.magnifier, .osd .scale-popup, .osd {
+popover.background.magnifier, .csd popover.background.osd, .csd popover.background.magnifier, .osd {
   color: #dbdbdb;
   border: none;
   background-color: #404040;
@@ -313,13 +313,16 @@ button {
   .titlebar button.text-button.titlebutton {
     padding-left: 5px;
     padding-right: 5px; }
-    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child, .titlebar button.text-button.titlebutton label:first-child {
+    button.text-button.image-button label:first-child, headerbar button.text-button.titlebutton label:first-child,
+    .titlebar button.text-button.titlebutton label:first-child {
       padding-left: 8px;
       padding-right: 2px; }
-    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child, .titlebar button.text-button.titlebutton label:last-child {
+    button.text-button.image-button label:last-child, headerbar button.text-button.titlebutton label:last-child,
+    .titlebar button.text-button.titlebutton label:last-child {
       padding-right: 8px;
       padding-left: 2px; }
-    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child, .titlebar button.text-button.titlebutton label:only-child {
+    button.text-button.image-button label:only-child, headerbar button.text-button.titlebutton label:only-child,
+    .titlebar button.text-button.titlebutton label:only-child {
       padding-left: 8px;
       padding-right: 8px; }
     button.text-button.image-button.popup, headerbar button.text-button.popup.titlebutton,
@@ -391,8 +394,7 @@ button {
         outline-color: rgba(255, 255, 255, 0.3);
         border-color: rgba(33, 33, 33, 0.4);
         background-color: #92b372; }
-  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child),
-  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
+  .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active):not(:only-child), .osd .linked:not(.vertical):not(.path-bar) > button:hover:not(:checked):not(:active) + button:not(:checked):not(:active) {
     box-shadow: none; }
   button.suggested-action {
     background-clip: border-box;
@@ -527,94 +529,70 @@ button {
     .inline-toolbar toolbutton > button:disabled:active label, .inline-toolbar toolbutton > button:disabled:checked label {
       color: inherit; }
 
-toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat, .linked:not(.vertical) > entry,
-.linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button,
-.linked:not(.vertical) > button:hover,
-.linked:not(.vertical) > button:active,
-.linked:not(.vertical) > button:checked, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .linked:not(.vertical).path-bar > button,
-headerbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
-.primary-toolbar .linked:not(.vertical).path-bar > button:hover,
-headerbar .linked:not(.vertical).path-bar > button:hover,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
-.primary-toolbar .linked:not(.vertical).path-bar > button:active,
-headerbar .linked:not(.vertical).path-bar > button:active,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
-.primary-toolbar .linked:not(.vertical).path-bar > button:checked,
-headerbar .linked:not(.vertical).path-bar > button:checked,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
-.primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
-headerbar .linked:not(.vertical).path-bar > button:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl) {
+.linked:not(.vertical) > combobox > box > button.combo:dir(ltr), .linked:not(.vertical) > combobox > box > button.combo:dir(rtl),
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button,
+headerbar .linked.path-bar:not(.vertical) > button, spinbutton:not(.vertical) button, spinbutton:not(.vertical) entry, .linked:not(.vertical) > entry, .linked:not(.vertical) > entry:focus, .inline-toolbar button, .inline-toolbar button:backdrop, .linked:not(.vertical) > button, .linked:not(.vertical) > button:hover, .linked:not(.vertical) > button:active, .linked:not(.vertical) > button:checked, toolbar.inline-toolbar toolbutton > button.flat, .inline-toolbar toolbutton > button.flat {
   border-radius: 0;
   border-right-style: none; }
 
-toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .linked:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:first-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:first-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:first-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:first-child,
-headerbar .linked:not(.vertical).path-bar > button:first-child,
-headerbar .linked:not(.vertical).path-bar > button:first-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:first-child:active,
-headerbar .linked:not(.vertical).path-bar > button:first-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:first-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:first-child:last-child:active, headerbar .linked:not(.vertical) entry + button:first-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:first-child:last-child:disabled, .linked:not(.vertical) > combobox:first-child > box > button.combo {
+popover.combo scrollbar.vertical:dir(rtl), .linked:not(.vertical) > combobox:first-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:first-child:last-child, headerbar .linked:not(.vertical) entry + button:first-child:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:first-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:first-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:first-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:first-child,
+headerbar .linked.path-bar:not(.vertical) > button:first-child, spinbutton:not(.vertical) button:first-child, spinbutton:not(.vertical) entry:first-child, .linked:not(.vertical) > entry:first-child, .inline-toolbar button:first-child, .inline-toolbar button:first-child:backdrop, .linked:not(.vertical) > button:first-child, toolbar.inline-toolbar toolbutton:first-child > button.flat, .inline-toolbar toolbutton:first-child > button.flat {
   border-top-left-radius: 3px;
   border-bottom-left-radius: 3px;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0; }
 
-toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .linked:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:last-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:last-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:last-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:last-child,
-headerbar .linked:not(.vertical).path-bar > button:last-child,
-headerbar .linked:not(.vertical).path-bar > button:last-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:last-child:active,
-headerbar .linked:not(.vertical).path-bar > button:last-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:last-child:disabled, .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover, .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked, .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled, .linked:not(.vertical) > combobox:last-child > box > button.combo {
+popover.combo scrollbar.vertical:dir(ltr), .linked:not(.vertical) > combobox:last-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:last-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:last-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:last-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:last-child,
+headerbar .linked.path-bar:not(.vertical) > button:last-child, spinbutton:not(.vertical) button:last-child, spinbutton:not(.vertical) entry:last-child, .linked:not(.vertical) > entry:last-child, .inline-toolbar button:last-child, .inline-toolbar button:last-child:backdrop, .linked:not(.vertical) > button:last-child, toolbar.inline-toolbar toolbutton:last-child > button.flat, .inline-toolbar toolbutton:last-child > button.flat {
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-right-style: solid; }
 
-toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .linked:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:only-child:disabled,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button:only-child,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:only-child,
-.primary-toolbar .linked:not(.vertical).path-bar > button:only-child,
-headerbar .linked:not(.vertical).path-bar > button:only-child,
-headerbar .linked:not(.vertical).path-bar > button:only-child:hover,
-headerbar .linked:not(.vertical).path-bar > button:only-child:active,
-headerbar .linked:not(.vertical).path-bar > button:only-child:checked,
-headerbar .linked:not(.vertical).path-bar > button:only-child:disabled, .primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child:hover, headerbar .linked:not(.vertical) entry + button:only-child:last-child:active, headerbar .linked:not(.vertical) entry + button:only-child:last-child:checked, headerbar .linked:not(.vertical) entry + button:only-child:last-child:disabled, .linked:not(.vertical) > combobox:only-child > box > button.combo {
+.linked:not(.vertical) > combobox:only-child > box > button.combo,
+.primary-toolbar .linked:not(.vertical) entry + button:only-child:last-child, headerbar .linked:not(.vertical) entry + button:only-child:last-child, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:only-child,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:only-child,
+.primary-toolbar .linked.path-bar:not(.vertical) > button:only-child,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:only-child,
+headerbar .linked.path-bar:not(.vertical) > button:only-child, spinbutton:not(.vertical) button:only-child, spinbutton:not(.vertical) entry:only-child, .linked:not(.vertical) > entry:only-child, .inline-toolbar button:only-child, .inline-toolbar button:only-child:backdrop, .linked:not(.vertical) > button:only-child, toolbar.inline-toolbar toolbutton:only-child > button.flat, .inline-toolbar toolbutton:only-child > button.flat {
   border-radius: 3px;
   border-style: solid; }
 
-.linked.vertical > entry,
-.linked.vertical > entry:focus, .linked.vertical > button,
-.linked.vertical > button:hover,
-.linked.vertical > button:active,
-.linked.vertical > button:checked, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > combobox > box > button.combo {
+.linked.vertical > combobox > box > button.combo, spinbutton.vertical button, spinbutton.vertical entry, .linked.vertical > entry, .linked.vertical > entry:focus, .linked.vertical > button, .linked.vertical > button:hover, .linked.vertical > button:active, .linked.vertical > button:checked {
   border-radius: 0;
   border-bottom-style: none; }
 
-.linked.vertical > entry:first-child, .linked.vertical > button:first-child, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > combobox:first-child > box > button.combo {
+list.content > row:first-child, list.content > row.expander:first-child row.header, list.content > row.expander:checked, list.content > row.expander:checked row.header, list.content > row.expander:checked + row, list.content > row.expander:checked + row.expander row.header, popover.combo overshoot.top, popover.combo list > row:first-child, .linked.vertical > combobox:first-child > box > button.combo, spinbutton.vertical button:first-child, spinbutton.vertical entry:first-child, .linked.vertical > entry:first-child, .linked.vertical > button:first-child {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px; }
 
-.linked.vertical > entry:last-child, .linked.vertical > button:last-child, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > combobox:last-child > box > button.combo {
+list.content > row:last-child, list.content > row.checked-expander-row-previous-sibling, list.content > row.expander:checked, list.content > row.expander:not(:checked):last-child row.header, list.content > row.expander.checked-expander-row-previous-sibling:not(:checked) row.header, list.content > row.expander.empty:checked row.header, list.content > row.expander list.nested > row:last-child, popover.combo overshoot.bottom, popover.combo list > row:last-child, .linked.vertical > combobox:last-child > box > button.combo, spinbutton.vertical button:last-child, spinbutton.vertical entry:last-child, .linked.vertical > entry:last-child, .linked.vertical > button:last-child {
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
   border-bottom-style: solid; }
 
-.linked.vertical > entry:only-child, .linked.vertical > button:only-child, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > combobox:only-child > box > button.combo {
+.linked.vertical > combobox:only-child > box > button.combo, spinbutton.vertical button:only-child, spinbutton.vertical entry:only-child, .linked.vertical > entry:only-child, .linked.vertical > button:only-child {
   border-radius: 3px;
   border-style: solid; }
 
-menuitem.button.flat,
-modelbutton.flat, button:link, button:visited, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, notebook > header > tabs > tab button.flat:hover, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, .app-notification button.flat, .app-notification button.flat:disabled, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active {
+TerminalWindow .notebook .active-page .button:active, TerminalWindow .notebook .prelight-page .button:active, TerminalWindow .notebook .active-page .button:hover, TerminalWindow .notebook .prelight-page .button:hover, TerminalWindow .notebook .active-page .button, TerminalWindow .notebook .prelight-page .button, .app-notification button.flat:disabled, .app-notification button.flat, notebook > header > tabs > tab button.flat:active, notebook > header > tabs > tab button.flat:active:hover, notebook > header > tabs > tab button.flat:hover, button:link:hover, button:link:active, button:link:checked, button:visited:hover, button:visited:active, button:visited:checked, button:link, button:visited, menuitem.button.flat,
+modelbutton.flat {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
@@ -657,28 +635,21 @@ button:link, button:visited,
   button:visited,
   *:link:visited {
     color: #5294E2; }
-    *:selected button:visited, *:selected
-    *:link:visited {
+    *:selected button:visited, *:selected *:link:visited {
       color: #d3e1c7; }
   button:hover:link, button:hover:visited,
   *:link:hover {
     color: #7eafe9; }
-    *:selected button:hover:link, *:selected button:hover:visited, *:selected
-    *:link:hover {
+    *:selected button:hover:link, *:selected button:hover:visited, *:selected *:link:hover {
       color: #f4f7f1; }
   button:active:link, button:active:visited,
   *:link:active {
     color: #5294E2; }
-    *:selected button:active:link, *:selected button:active:visited, *:selected
-    *:link:active {
+    *:selected button:active:link, *:selected button:active:visited, *:selected *:link:active {
       color: #e9f0e3; }
-  headerbar.selection-mode .subtitle:link,
-  .selection-mode.titlebar:not(headerbar) .subtitle:link, infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, button:selected:link, button:selected:visited,
-  *:selected button:link,
-  *:selected button:visited,
-  *:link:selected,
-  *:selected
-  *:link {
+  infobar.info *:link, infobar.question *:link, infobar.warning *:link, infobar.error *:link, headerbar.selection-mode .subtitle:link,
+  .selection-mode.titlebar:not(headerbar) .subtitle:link, button:selected:link, button:selected:visited, *:selected button:link, *:selected button:visited,
+  *:link:selected, *:selected *:link {
     color: #e9f0e3; }
 
 button:link > label, button:visited > label {
@@ -696,8 +667,7 @@ spinbutton:disabled {
 spinbutton:not(.vertical) entry {
   min-width: 28px; }
 
-spinbutton:not(.vertical):dir(ltr) entry,
-spinbutton:not(.vertical):dir(rtl) button.up {
+spinbutton:not(.vertical):dir(ltr) entry, spinbutton:not(.vertical):dir(rtl) button.up {
   border-radius: 3px 0 0 3px; }
 
 spinbutton:not(.vertical) > button + button {
@@ -918,28 +888,18 @@ headerbar,
         -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); }
     .maximized headerbar.selection-mode, .maximized .selection-mode.titlebar:not(headerbar) {
       background-color: #92b372; }
-  .tiled headerbar, .tiled headerbar:backdrop,
-  .maximized headerbar, .maximized headerbar:backdrop, .tiled .titlebar:not(headerbar), .tiled .titlebar:backdrop:not(headerbar),
-  .maximized .titlebar:not(headerbar), .maximized .titlebar:backdrop:not(headerbar) {
+  .tiled headerbar, .tiled headerbar:backdrop, .maximized headerbar, .maximized headerbar:backdrop, .tiled .titlebar:not(headerbar), .maximized .titlebar:not(headerbar) {
     border-radius: 0; }
-  .maximized headerbar,
-  .maximized .titlebar:not(headerbar) {
+  .maximized headerbar, .maximized .titlebar:not(headerbar) {
     background-color: #d9d9d9;
     border-color: #bdbdbd; }
-  headerbar.default-decoration,
-  .csd headerbar.default-decoration, headerbar.default-decoration:backdrop,
-  .csd headerbar.default-decoration:backdrop,
-  .default-decoration.titlebar:not(headerbar),
-  .csd .default-decoration.titlebar:not(headerbar),
-  .default-decoration.titlebar:backdrop:not(headerbar),
-  .csd .default-decoration.titlebar:backdrop:not(headerbar) {
+  headerbar.default-decoration, .csd headerbar.default-decoration, headerbar.default-decoration:backdrop, .csd headerbar.default-decoration:backdrop,
+  .default-decoration.titlebar:not(headerbar) {
     min-height: 28px;
     padding: 0 7px;
     background-color: #d9d9d9;
     border-bottom-width: 0; }
-    .maximized headerbar.default-decoration, .maximized
-    .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized
-    .csd headerbar.default-decoration:backdrop, .maximized .default-decoration.titlebar:not(headerbar), .maximized .csd .default-decoration.titlebar:not(headerbar), .maximized .default-decoration.titlebar:backdrop:not(headerbar), .maximized .csd .default-decoration.titlebar:backdrop:not(headerbar) {
+    .maximized headerbar.default-decoration, .maximized .csd headerbar.default-decoration, .maximized headerbar.default-decoration:backdrop, .maximized .csd headerbar.default-decoration:backdrop, .maximized .default-decoration.titlebar:not(headerbar) {
       background-color: #d9d9d9; }
 
 .titlebar {
@@ -951,23 +911,15 @@ headerbar entry, headerbar button, headerbar separator {
 
 separator:first-child + headerbar, separator:first-child + headerbar:backdrop, headerbar:first-child, headerbar:first-child:backdrop {
   border-top-left-radius: 3px; }
-  .maximized separator:first-child + headerbar,
-  .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop,
-  .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child,
-  .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop,
-  .tiled headerbar:first-child:backdrop {
+  .maximized separator:first-child + headerbar, .tiled separator:first-child + headerbar, .maximized separator:first-child + headerbar:backdrop, .tiled separator:first-child + headerbar:backdrop, .maximized headerbar:first-child, .tiled headerbar:first-child, .maximized headerbar:first-child:backdrop, .tiled headerbar:first-child:backdrop {
     border-radius: 0; }
 
 headerbar:last-child, headerbar:last-child:backdrop {
   border-top-right-radius: 3px; }
-  .maximized headerbar:last-child,
-  .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop,
-  .tiled headerbar:last-child:backdrop {
+  .maximized headerbar:last-child, .tiled headerbar:last-child, .maximized headerbar:last-child:backdrop, .tiled headerbar:last-child:backdrop {
     border-radius: 0; }
 
-window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop,
-window.csd > .titlebar:not(headerbar),
-window.csd > .titlebar:not(headerbar):backdrop {
+window > .titlebar:not(headerbar), window > .titlebar:not(headerbar):backdrop, window.csd > .titlebar:not(headerbar), window.csd > .titlebar:not(headerbar):backdrop {
   padding: 0;
   background: none;
   border: none;
@@ -976,358 +928,440 @@ window.csd > .titlebar:not(headerbar):backdrop {
 .titlebar:not(headerbar) > separator {
   background-image: linear-gradient(to bottom, #BDBDBD, #BDBDBD); }
 
-.primary-toolbar toolbar separator, .primary-toolbar .inline-toolbar separator,
-.primary-toolbar:not(.libreoffice-toolbar) separator {
+.primary-toolbar toolbar separator,
+.primary-toolbar:not(.libreoffice-toolbar) separator, .primary-toolbar .inline-toolbar separator {
   min-width: 1px;
   min-height: 1px;
   border-width: 0 1px;
   border-image: linear-gradient(to bottom, rgba(64, 64, 64, 0) 25%, rgba(64, 64, 64, 0.35) 25%, rgba(64, 64, 64, 0.35) 75%, rgba(64, 64, 64, 0) 75%) 0 1/0 1px stretch; }
-  .primary-toolbar toolbar separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop,
-  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop {
+  .primary-toolbar toolbar separator:backdrop,
+  .primary-toolbar:not(.libreoffice-toolbar) separator:backdrop, .primary-toolbar .inline-toolbar separator:backdrop {
     opacity: 0.6; }
 
-.primary-toolbar toolbar entry, .primary-toolbar .inline-toolbar entry, .primary-toolbar entry, headerbar entry {
+
+.primary-toolbar entry, headerbar entry {
   color: #404040;
   border-color: rgba(64, 64, 64, 0.3);
   background-color: rgba(255, 255, 255, 0.9); }
-  .primary-toolbar toolbar entry image, .primary-toolbar .inline-toolbar entry image, .primary-toolbar entry image, headerbar entry image, .primary-toolbar toolbar entry image:hover, .primary-toolbar .inline-toolbar entry image:hover, .primary-toolbar entry image:hover, headerbar entry image:hover {
+  
+  .primary-toolbar entry image, headerbar entry image {
     color: inherit; }
-  .primary-toolbar toolbar entry:backdrop, .primary-toolbar .inline-toolbar entry:backdrop, .primary-toolbar entry:backdrop, headerbar entry:backdrop {
+  
+  .primary-toolbar entry:backdrop, headerbar entry:backdrop {
     opacity: 0.85; }
-  .primary-toolbar toolbar entry:focus, .primary-toolbar .inline-toolbar entry:focus, .primary-toolbar entry:focus, headerbar entry:focus {
+  
+  .primary-toolbar entry:focus, headerbar entry:focus {
     color: #404040;
     border-color: #92b372;
     background-color: rgba(255, 255, 255, 0.9);
     background-clip: border-box; }
-    .primary-toolbar toolbar entry:focus image, .primary-toolbar .inline-toolbar entry:focus image, .primary-toolbar entry:focus image, headerbar entry:focus image {
+    
+    .primary-toolbar entry:focus image, headerbar entry:focus image {
       color: rgba(64, 64, 64, 0.85); }
-  .primary-toolbar toolbar entry:disabled, .primary-toolbar .inline-toolbar entry:disabled, .primary-toolbar entry:disabled, headerbar entry:disabled {
+  
+  .primary-toolbar entry:disabled, headerbar entry:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(255, 255, 255, 0.75); }
-  .primary-toolbar toolbar entry selection:focus, .primary-toolbar .inline-toolbar entry selection:focus, .primary-toolbar entry selection:focus, headerbar entry selection:focus {
+  
+  .primary-toolbar entry selection:focus, headerbar entry selection:focus {
     background-color: #92b372;
     color: #ffffff; }
-  .primary-toolbar toolbar entry progress, .primary-toolbar .inline-toolbar entry progress, .primary-toolbar entry progress, headerbar entry progress {
+  
+  .primary-toolbar entry progress, headerbar entry progress {
     border-color: #92b372;
     background-image: none;
     background-color: transparent; }
-  .primary-toolbar toolbar entry.warning, .primary-toolbar .inline-toolbar entry.warning, .primary-toolbar entry.warning, headerbar entry.warning {
+  
+  .primary-toolbar entry.warning, headerbar entry.warning {
     color: white;
     border-color: #f27835;
     background-color: #e89f77; }
-    .primary-toolbar toolbar entry.warning:focus, .primary-toolbar .inline-toolbar entry.warning:focus, .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
+    
+    .primary-toolbar entry.warning:focus, headerbar entry.warning:focus {
       color: white;
       background-color: #f27835; }
-    .primary-toolbar toolbar entry.warning selection, .primary-toolbar .inline-toolbar entry.warning selection, .primary-toolbar entry.warning selection, headerbar entry.warning selection, .primary-toolbar toolbar entry.warning selection:focus, .primary-toolbar .inline-toolbar entry.warning selection:focus, .primary-toolbar entry.warning selection:focus, headerbar entry.warning selection:focus {
+    
+    .primary-toolbar entry.warning selection, headerbar entry.warning selection {
       background-color: white;
       color: #f27835; }
-  .primary-toolbar toolbar entry.error, .primary-toolbar .inline-toolbar entry.error, .primary-toolbar entry.error, headerbar entry.error {
+  
+  .primary-toolbar entry.error, headerbar entry.error {
     color: white;
     border-color: #FC4138;
     background-color: #ee7e78; }
-    .primary-toolbar toolbar entry.error:focus, .primary-toolbar .inline-toolbar entry.error:focus, .primary-toolbar entry.error:focus, headerbar entry.error:focus {
+    
+    .primary-toolbar entry.error:focus, headerbar entry.error:focus {
       color: white;
       background-color: #FC4138; }
-    .primary-toolbar toolbar entry.error selection, .primary-toolbar .inline-toolbar entry.error selection, .primary-toolbar entry.error selection, headerbar entry.error selection, .primary-toolbar toolbar entry.error selection:focus, .primary-toolbar .inline-toolbar entry.error selection:focus, .primary-toolbar entry.error selection:focus, headerbar entry.error selection:focus {
+    
+    .primary-toolbar entry.error selection, headerbar entry.error selection {
       background-color: white;
       color: #FC4138; }
 
-.primary-toolbar toolbar button, .primary-toolbar .inline-toolbar button, .primary-toolbar button, headerbar button {
+
+.primary-toolbar button, headerbar button {
   color: #404040;
   outline-color: rgba(64, 64, 64, 0.3);
   outline-offset: -3px;
   background-color: rgba(217, 217, 217, 0);
   border-color: rgba(217, 217, 217, 0); }
-  .primary-toolbar toolbar button:backdrop, .primary-toolbar .inline-toolbar button:backdrop, .primary-toolbar button:backdrop, headerbar button:backdrop {
+  
+  .primary-toolbar button:backdrop, headerbar button:backdrop {
     opacity: 0.7; }
-  .primary-toolbar toolbar button:hover, .primary-toolbar .inline-toolbar button:hover, .primary-toolbar button:hover, headerbar button:hover {
+  
+  .primary-toolbar button:hover, headerbar button:hover {
     color: #404040;
     outline-color: rgba(64, 64, 64, 0.3);
     border-color: rgba(64, 64, 64, 0.3);
     background-color: rgba(245, 245, 245, 0.9); }
-  .primary-toolbar toolbar button:active, .primary-toolbar .inline-toolbar button:active, .primary-toolbar button:active, headerbar button:active, .primary-toolbar toolbar button:checked, .primary-toolbar .inline-toolbar button:checked, .primary-toolbar button:checked, headerbar button:checked {
+  
+  .primary-toolbar button:active, headerbar button:active,
+  .primary-toolbar button:checked, headerbar button:checked {
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(64, 64, 64, 0.3);
     background-color: #92b372;
     background-clip: border-box; }
-  .primary-toolbar toolbar button:disabled, .primary-toolbar .inline-toolbar button:disabled, .primary-toolbar button:disabled, headerbar button:disabled {
+  
+  .primary-toolbar button:disabled, headerbar button:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(217, 217, 217, 0);
     border-color: rgba(217, 217, 217, 0); }
-    .primary-toolbar toolbar button:disabled label, .primary-toolbar .inline-toolbar button:disabled label, .primary-toolbar button:disabled label, headerbar button:disabled label {
+    
+    .primary-toolbar button:disabled label, headerbar button:disabled label {
       color: inherit; }
-  .primary-toolbar toolbar button:disabled:active, .primary-toolbar .inline-toolbar button:disabled:active, .primary-toolbar button:disabled:active, headerbar button:disabled:active, .primary-toolbar toolbar button:disabled:checked, .primary-toolbar .inline-toolbar button:disabled:checked, .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
+  
+  .primary-toolbar button:disabled:active, headerbar button:disabled:active,
+  .primary-toolbar button:disabled:checked, headerbar button:disabled:checked {
     color: rgba(255, 255, 255, 0.75);
     border-color: rgba(146, 179, 114, 0.65);
     background-color: rgba(146, 179, 114, 0.65); }
 
-.primary-toolbar toolbar.selection-mode button, .primary-toolbar .selection-mode.inline-toolbar button, .selection-mode.primary-toolbar button, headerbar.selection-mode button, .primary-toolbar toolbar.selection-mode button.flat, .primary-toolbar .selection-mode.inline-toolbar button.flat, .selection-mode.primary-toolbar button.flat, headerbar.selection-mode button.flat {
+.primary-toolbar toolbar.selection-mode button,
+.selection-mode.primary-toolbar button, .primary-toolbar .selection-mode.inline-toolbar button, headerbar.selection-mode button {
   border-color: transparent;
   background-color: transparent;
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
 
+
 .primary-toolbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child), headerbar .linked:not(.vertical):not(.path-bar):not(.stack-switcher) button:not(:last-child):not(:only-child) {
   margin-right: 1px; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:hover, headerbar .linked:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:active, headerbar .linked:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:checked, headerbar .linked:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked:not(.vertical):not(.path-bar) > button:disabled {
+.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button, headerbar .linked:not(.vertical):not(.path-bar) > button {
   border-radius: 3px;
   border-style: solid; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
+
+.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action), headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action) + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
 .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
 .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
 headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover:not(:only-child),
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):hover + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action),
 .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
 .primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-.primary-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover),
-headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled + button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):not(:hover) {
+.primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child),
+headerbar .linked:not(.vertical):not(.path-bar) > button:not(:checked):not(:active):not(.suggested-action):not(.destructive-action):disabled:not(:only-child) {
   box-shadow: none; }
 
-.primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button,
-.primary-toolbar toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button,
-.primary-toolbar .linked:not(.vertical).path-bar > button,
-headerbar .linked:not(.vertical).path-bar > button {
+.primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button,
+.primary-toolbar toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .linked.path-bar:not(.vertical) > button,
+.primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button,
+headerbar .linked.path-bar:not(.vertical) > button {
   color: #404040;
   outline-color: rgba(64, 64, 64, 0.3);
   border-color: rgba(64, 64, 64, 0.3);
   background-color: rgba(245, 245, 245, 0.9); }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:hover,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:hover,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:hover,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:hover,
-  headerbar .linked:not(.vertical).path-bar > button:hover {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:hover,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:hover,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:hover,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:hover,
+  headerbar .linked.path-bar:not(.vertical) > button:hover {
     background-color: rgba(255, 255, 255, 0.9); }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:active, .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:checked,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:active,
-  headerbar .linked:not(.vertical).path-bar > button:active,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:checked,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:checked,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:checked,
-  headerbar .linked:not(.vertical).path-bar > button:checked {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:active, .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:checked,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:active,
+  headerbar .linked.path-bar:not(.vertical) > button:active,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:checked,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:checked,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:checked,
+  headerbar .linked.path-bar:not(.vertical) > button:checked {
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     border-color: rgba(64, 64, 64, 0.3);
     background-color: #92b372; }
-  .primary-toolbar toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .inline-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, .primary-toolbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled, headerbar .linked:not(.vertical):not(.path-bar).stack-switcher > button:disabled,
-  .primary-toolbar toolbar .linked:not(.vertical).path-bar > button:disabled,
-  .primary-toolbar .inline-toolbar .linked:not(.vertical).path-bar > button:disabled,
-  .primary-toolbar .linked:not(.vertical).path-bar > button:disabled,
-  headerbar .linked:not(.vertical).path-bar > button:disabled {
+  .primary-toolbar toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled,
+  .primary-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled, .primary-toolbar .inline-toolbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled, headerbar .linked.stack-switcher:not(.vertical):not(.path-bar) > button:disabled,
+  .primary-toolbar toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  .primary-toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  .primary-toolbar .inline-toolbar .linked.path-bar:not(.vertical) > button:disabled,
+  headerbar .linked.path-bar:not(.vertical) > button:disabled {
     color: rgba(64, 64, 64, 0.6); }
 
-.primary-toolbar toolbar .linked:not(.vertical) entry, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry, .primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
+
+.primary-toolbar .linked:not(.vertical) entry, headerbar .linked:not(.vertical) entry {
   box-shadow: none; }
-  .primary-toolbar toolbar .linked:not(.vertical) entry:focus, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry:focus, .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
+  
+  .primary-toolbar .linked:not(.vertical) entry:focus, headerbar .linked:not(.vertical) entry:focus {
     color: #404040;
     border-color: rgba(64, 64, 64, 0.3);
     background-color: rgba(255, 255, 255, 0.9);
     background-clip: padding-box; }
-    .primary-toolbar toolbar .linked:not(.vertical) entry:focus image, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry:focus image, .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image, .primary-toolbar .linked:not(.vertical) entry:focus image:hover, headerbar .linked:not(.vertical) entry:focus image:hover {
+    
+    .primary-toolbar .linked:not(.vertical) entry:focus image, headerbar .linked:not(.vertical) entry:focus image {
       color: inherit; }
-  .primary-toolbar toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .inline-toolbar .linked:not(.vertical) entry + button:last-child, .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
+  
+  .primary-toolbar .linked:not(.vertical) entry + button:last-child, headerbar .linked:not(.vertical) entry + button:last-child {
     color: #404040;
     outline-color: rgba(64, 64, 64, 0.3);
     border-color: rgba(64, 64, 64, 0.3);
     background-color: rgba(245, 245, 245, 0.9); }
+    
     .primary-toolbar .linked:not(.vertical) entry + button:last-child:hover, headerbar .linked:not(.vertical) entry + button:last-child:hover {
       background-color: rgba(255, 255, 255, 0.9); }
-    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active, .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
+    
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:active, headerbar .linked:not(.vertical) entry + button:last-child:active,
+    .primary-toolbar .linked:not(.vertical) entry + button:last-child:checked, headerbar .linked:not(.vertical) entry + button:last-child:checked {
       color: #ffffff;
       outline-color: rgba(255, 255, 255, 0.3);
       border-color: rgba(64, 64, 64, 0.3);
       background-color: #92b372; }
+    
     .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled, headerbar .linked:not(.vertical) entry + button:last-child:disabled {
       color: rgba(64, 64, 64, 0.6);
       background-color: rgba(245, 245, 245, 0.7);
       border-color: rgba(64, 64, 64, 0.3); }
+      
       .primary-toolbar .linked:not(.vertical) entry + button:last-child:disabled:checked, headerbar .linked:not(.vertical) entry + button:last-child:disabled:checked {
         background-color: rgba(146, 179, 114, 0.65);
         color: rgba(255, 255, 255, 0.75); }
 
-.primary-toolbar toolbar button.suggested-action, .primary-toolbar .inline-toolbar button.suggested-action, .primary-toolbar button.suggested-action, headerbar button.suggested-action {
+
+.primary-toolbar button.suggested-action, headerbar button.suggested-action {
   background-clip: border-box;
   color: #ffffff;
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #6db442;
   border-color: #6db442; }
-  .primary-toolbar toolbar button.suggested-action.flat, .primary-toolbar .inline-toolbar button.suggested-action.flat, .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
+  
+  .primary-toolbar button.suggested-action.flat, headerbar button.suggested-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     color: #6db442;
     outline-color: rgba(109, 180, 66, 0.3); }
-  .primary-toolbar toolbar button.suggested-action:hover, .primary-toolbar .inline-toolbar button.suggested-action:hover, .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
+  
+  .primary-toolbar button.suggested-action:hover, headerbar button.suggested-action:hover {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #88c663;
     border-color: #88c663; }
-  .primary-toolbar toolbar button.suggested-action:active, .primary-toolbar .inline-toolbar button.suggested-action:active, .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active, .primary-toolbar toolbar button.suggested-action:checked, .primary-toolbar .inline-toolbar button.suggested-action:checked, .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
+  
+  .primary-toolbar button.suggested-action:active, headerbar button.suggested-action:active,
+  .primary-toolbar button.suggested-action:checked, headerbar button.suggested-action:checked {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #568f34;
     border-color: #568f34; }
-  .primary-toolbar toolbar button.suggested-action.flat:disabled, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled, .primary-toolbar button.suggested-action.flat:disabled, headerbar button.suggested-action.flat:disabled, .primary-toolbar toolbar button.suggested-action:disabled, .primary-toolbar .inline-toolbar button.suggested-action:disabled, .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
+  
+  .primary-toolbar button.suggested-action:disabled, headerbar button.suggested-action:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(217, 217, 217, 0);
     border-color: rgba(217, 217, 217, 0); }
-    .primary-toolbar toolbar button.suggested-action.flat:disabled label, .primary-toolbar .inline-toolbar button.suggested-action.flat:disabled label, .primary-toolbar button.suggested-action.flat:disabled label, headerbar button.suggested-action.flat:disabled label, .primary-toolbar toolbar button.suggested-action:disabled label, .primary-toolbar .inline-toolbar button.suggested-action:disabled label, .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
+    
+    .primary-toolbar button.suggested-action:disabled label, headerbar button.suggested-action:disabled label {
       color: inherit; }
 
-.primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop, .primary-toolbar toolbar button.suggested-action:backdrop, .primary-toolbar .inline-toolbar button.suggested-action:backdrop, .primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
+
+.primary-toolbar button.suggested-action:backdrop, headerbar button.suggested-action:backdrop {
   opacity: 0.8; }
 
-.primary-toolbar toolbar button.destructive-action, .primary-toolbar .inline-toolbar button.destructive-action, .primary-toolbar button.destructive-action, headerbar button.destructive-action {
+
+.primary-toolbar button.destructive-action, headerbar button.destructive-action {
   background-clip: border-box;
   color: #ffffff;
   outline-color: rgba(255, 255, 255, 0.3);
   background-color: #F04A50;
   border-color: #F04A50; }
-  .primary-toolbar toolbar button.destructive-action.flat, .primary-toolbar .inline-toolbar button.destructive-action.flat, .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
+  
+  .primary-toolbar button.destructive-action.flat, headerbar button.destructive-action.flat {
     border-color: transparent;
     background-color: transparent;
     background-image: none;
     color: #F04A50;
     outline-color: rgba(240, 74, 80, 0.3); }
-  .primary-toolbar toolbar button.destructive-action:hover, .primary-toolbar .inline-toolbar button.destructive-action:hover, .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
+  
+  .primary-toolbar button.destructive-action:hover, headerbar button.destructive-action:hover {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #f4797e;
     border-color: #f4797e; }
-  .primary-toolbar toolbar button.destructive-action:active, .primary-toolbar .inline-toolbar button.destructive-action:active, .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active, .primary-toolbar toolbar button.destructive-action:checked, .primary-toolbar .inline-toolbar button.destructive-action:checked, .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
+  
+  .primary-toolbar button.destructive-action:active, headerbar button.destructive-action:active,
+  .primary-toolbar button.destructive-action:checked, headerbar button.destructive-action:checked {
     background-clip: border-box;
     color: #ffffff;
     outline-color: rgba(255, 255, 255, 0.3);
     background-color: #ec1b22;
     border-color: #ec1b22; }
-  .primary-toolbar toolbar button.destructive-action.flat:disabled, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled, .primary-toolbar button.destructive-action.flat:disabled, headerbar button.destructive-action.flat:disabled, .primary-toolbar toolbar button.destructive-action:disabled, .primary-toolbar .inline-toolbar button.destructive-action:disabled, .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
+  
+  .primary-toolbar button.destructive-action:disabled, headerbar button.destructive-action:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(217, 217, 217, 0);
     border-color: rgba(217, 217, 217, 0); }
-    .primary-toolbar toolbar button.destructive-action.flat:disabled label, .primary-toolbar .inline-toolbar button.destructive-action.flat:disabled label, .primary-toolbar button.destructive-action.flat:disabled label, headerbar button.destructive-action.flat:disabled label, .primary-toolbar toolbar button.destructive-action:disabled label, .primary-toolbar .inline-toolbar button.destructive-action:disabled label, .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
+    
+    .primary-toolbar button.destructive-action:disabled label, headerbar button.destructive-action:disabled label {
       color: inherit; }
 
-.primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop, .primary-toolbar toolbar button.destructive-action:backdrop, .primary-toolbar .inline-toolbar button.destructive-action:backdrop, .primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
+
+.primary-toolbar button.destructive-action:backdrop, headerbar button.destructive-action:backdrop {
   opacity: 0.8; }
 
-.primary-toolbar toolbar spinbutton:focus button, .primary-toolbar .inline-toolbar spinbutton:focus button, .primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
+
+.primary-toolbar spinbutton:focus button, headerbar spinbutton:focus button {
   color: #ffffff; }
-  .primary-toolbar toolbar spinbutton:focus button:hover, .primary-toolbar .inline-toolbar spinbutton:focus button:hover, .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
+  
+  .primary-toolbar spinbutton:focus button:hover, headerbar spinbutton:focus button:hover {
     background-color: rgba(255, 255, 255, 0.1);
     border-color: transparent; }
-  .primary-toolbar toolbar spinbutton:focus button:disabled, .primary-toolbar .inline-toolbar spinbutton:focus button:disabled, .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
+  
+  .primary-toolbar spinbutton:focus button:disabled, headerbar spinbutton:focus button:disabled {
     color: rgba(255, 255, 255, 0.4); }
 
-.primary-toolbar toolbar spinbutton button, .primary-toolbar .inline-toolbar spinbutton button, .primary-toolbar spinbutton button, headerbar spinbutton button {
+
+.primary-toolbar spinbutton button, headerbar spinbutton button {
   color: #404040; }
-  .primary-toolbar toolbar spinbutton button:hover, .primary-toolbar .inline-toolbar spinbutton button:hover, .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
+  
+  .primary-toolbar spinbutton button:hover, headerbar spinbutton button:hover {
     background-color: rgba(64, 64, 64, 0.25);
     border-color: transparent; }
-  .primary-toolbar toolbar spinbutton button:disabled, .primary-toolbar .inline-toolbar spinbutton button:disabled, .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
+  
+  .primary-toolbar spinbutton button:disabled, headerbar spinbutton button:disabled {
     color: rgba(64, 64, 64, 0.7); }
-  .primary-toolbar toolbar spinbutton button:active, .primary-toolbar .inline-toolbar spinbutton button:active, .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
+  
+  .primary-toolbar spinbutton button:active, headerbar spinbutton button:active {
     background-color: rgba(0, 0, 0, 0.1); }
 
-.primary-toolbar toolbar combobox:disabled, .primary-toolbar .inline-toolbar combobox:disabled, .primary-toolbar combobox:disabled, headerbar combobox:disabled {
+
+.primary-toolbar combobox:disabled, headerbar combobox:disabled {
   color: rgba(64, 64, 64, 0.4); }
 
-.primary-toolbar toolbar combobox > .linked > button.combo, .primary-toolbar .inline-toolbar combobox > .linked > button.combo, .primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
+
+.primary-toolbar combobox > .linked > button.combo, headerbar combobox > .linked > button.combo {
   color: #404040;
   border-color: rgba(64, 64, 64, 0.3);
   background-color: rgba(255, 255, 255, 0.9); }
-  .primary-toolbar toolbar combobox > .linked > button.combo image, .primary-toolbar .inline-toolbar combobox > .linked > button.combo image, .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image, .primary-toolbar toolbar combobox > .linked > button.combo image:hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo image:hover, .primary-toolbar combobox > .linked > button.combo image:hover, headerbar combobox > .linked > button.combo image:hover {
+  
+  .primary-toolbar combobox > .linked > button.combo image, headerbar combobox > .linked > button.combo image {
     color: inherit; }
-  .primary-toolbar toolbar combobox > .linked > button.combo:hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:hover, .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
+  
+  .primary-toolbar combobox > .linked > button.combo:hover, headerbar combobox > .linked > button.combo:hover {
     color: #404040;
     border-color: #92b372;
     background-color: rgba(255, 255, 255, 0.9);
     box-shadow: none; }
-  .primary-toolbar toolbar combobox > .linked > button.combo:disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:disabled, .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
+  
+  .primary-toolbar combobox > .linked > button.combo:disabled, headerbar combobox > .linked > button.combo:disabled {
     color: rgba(64, 64, 64, 0.55);
     background-color: rgba(255, 255, 255, 0.75); }
 
-.primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr), .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr), .primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
+
+.primary-toolbar combobox > .linked > entry.combo:dir(ltr), headerbar combobox > .linked > entry.combo:dir(ltr) {
   border-right-style: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
     box-shadow: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(ltr):focus, .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(ltr):focus, headerbar combobox > .linked > entry.combo:dir(ltr):focus {
     box-shadow: 1px 0 #92b372; }
 
-.primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl), .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl), .primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
+
+.primary-toolbar combobox > .linked > entry.combo:dir(rtl), headerbar combobox > .linked > entry.combo:dir(rtl) {
   border-left-style: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
     box-shadow: none; }
-  .primary-toolbar toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar .inline-toolbar combobox > .linked > entry.combo:dir(rtl):focus, .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
+  
+  .primary-toolbar combobox > .linked > entry.combo:dir(rtl):focus, headerbar combobox > .linked > entry.combo:dir(rtl):focus {
     box-shadow: -1px 0 #92b372; }
 
-.primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr), .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar combobox > .linked > button.combo:dir(ltr):hover, headerbar combobox > .linked > button.combo:dir(ltr):hover, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar combobox > .linked > button.combo:dir(ltr):active, headerbar combobox > .linked > button.combo:dir(ltr):active, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar combobox > .linked > button.combo:dir(ltr):checked, headerbar combobox > .linked > button.combo:dir(ltr):checked, .primary-toolbar toolbar combobox > .linked > button.combo:dir(ltr):disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(ltr):disabled, .primary-toolbar combobox > .linked > button.combo:dir(ltr):disabled, headerbar combobox > .linked > button.combo:dir(ltr):disabled {
+
+.primary-toolbar combobox > .linked > button.combo:dir(ltr), headerbar combobox > .linked > button.combo:dir(ltr) {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0; }
 
-.primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl), .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar combobox > .linked > button.combo:dir(rtl):hover, headerbar combobox > .linked > button.combo:dir(rtl):hover, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar combobox > .linked > button.combo:dir(rtl):active, headerbar combobox > .linked > button.combo:dir(rtl):active, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar combobox > .linked > button.combo:dir(rtl):checked, headerbar combobox > .linked > button.combo:dir(rtl):checked, .primary-toolbar toolbar combobox > .linked > button.combo:dir(rtl):disabled, .primary-toolbar .inline-toolbar combobox > .linked > button.combo:dir(rtl):disabled, .primary-toolbar combobox > .linked > button.combo:dir(rtl):disabled, headerbar combobox > .linked > button.combo:dir(rtl):disabled {
+
+.primary-toolbar combobox > .linked > button.combo:dir(rtl), headerbar combobox > .linked > button.combo:dir(rtl) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0; }
 
-.primary-toolbar toolbar switch:backdrop, .primary-toolbar .inline-toolbar switch:backdrop, .primary-toolbar switch:backdrop, headerbar switch:backdrop {
+
+.primary-toolbar switch:backdrop, headerbar switch:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar progressbar trough, .primary-toolbar .inline-toolbar progressbar trough, .primary-toolbar progressbar trough, headerbar progressbar trough {
+
+.primary-toolbar progressbar trough, headerbar progressbar trough {
   background-color: rgba(64, 64, 64, 0.35); }
 
-.primary-toolbar toolbar progressbar:backdrop, .primary-toolbar .inline-toolbar progressbar:backdrop, .primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
+
+.primary-toolbar progressbar:backdrop, headerbar progressbar:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar scale:backdrop, .primary-toolbar .inline-toolbar scale:backdrop, .primary-toolbar scale:backdrop, headerbar scale:backdrop {
+
+.primary-toolbar scale:backdrop, headerbar scale:backdrop {
   opacity: 0.75; }
 
-.primary-toolbar toolbar scale slider, .primary-toolbar .inline-toolbar scale slider, .primary-toolbar scale slider, headerbar scale slider {
+
+.primary-toolbar scale slider, headerbar scale slider {
   background-color: whitesmoke;
   border-color: rgba(64, 64, 64, 0.5); }
-  .primary-toolbar toolbar scale slider:hover, .primary-toolbar .inline-toolbar scale slider:hover, .primary-toolbar scale slider:hover, headerbar scale slider:hover {
+  
+  .primary-toolbar scale slider:hover, headerbar scale slider:hover {
     background-color: white;
     border-color: rgba(64, 64, 64, 0.5); }
-  .primary-toolbar toolbar scale slider:active, .primary-toolbar .inline-toolbar scale slider:active, .primary-toolbar scale slider:active, headerbar scale slider:active {
+  
+  .primary-toolbar scale slider:active, headerbar scale slider:active {
     background-color: #92b372;
     border-color: #92b372; }
-  .primary-toolbar toolbar scale slider:disabled, .primary-toolbar .inline-toolbar scale slider:disabled, .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
+  
+  .primary-toolbar scale slider:disabled, headerbar scale slider:disabled {
     background-color: #ededed;
     border-color: rgba(64, 64, 64, 0.5); }
 
-.primary-toolbar toolbar scale trough, .primary-toolbar .inline-toolbar scale trough, .primary-toolbar scale trough, headerbar scale trough {
+
+.primary-toolbar scale trough, headerbar scale trough {
   background-color: rgba(64, 64, 64, 0.35); }
-  .primary-toolbar toolbar scale trough:disabled, .primary-toolbar .inline-toolbar scale trough:disabled, .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
+  
+  .primary-toolbar scale trough:disabled, headerbar scale trough:disabled {
     background-color: rgba(64, 64, 64, 0.3); }
 
 .path-bar button.text-button, .path-bar button.image-button, .path-bar headerbar button.titlebutton, headerbar .path-bar button.titlebutton,
-.path-bar .titlebar button.titlebutton, .titlebar .path-bar button.titlebutton, .path-bar button {
+.path-bar .titlebar button.titlebutton,
+.titlebar .path-bar button.titlebutton, .path-bar button {
   padding-left: 6px;
   padding-right: 6px; }
 
-.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label, .path-bar .titlebar button.text-button.titlebutton label, .titlebar .path-bar button.text-button.titlebutton label {
+.path-bar button.text-button.image-button label, .path-bar headerbar button.text-button.titlebutton label, headerbar .path-bar button.text-button.titlebutton label,
+.path-bar .titlebar button.text-button.titlebutton label,
+.titlebar .path-bar button.text-button.titlebutton label {
   padding-left: 0;
   padding-right: 0; }
 
-.path-bar button.text-button.image-button label:last-child, .path-bar headerbar button.text-button.titlebutton label:last-child, headerbar .path-bar button.text-button.titlebutton label:last-child, .path-bar .titlebar button.text-button.titlebutton label:last-child, .titlebar .path-bar button.text-button.titlebutton label:last-child, .path-bar button label:last-child {
+.path-bar button.text-button.image-button label:last-child, .path-bar button label:last-child {
   padding-right: 10px; }
 
-.path-bar button.text-button.image-button label:first-child, .path-bar headerbar button.text-button.titlebutton label:first-child, headerbar .path-bar button.text-button.titlebutton label:first-child, .path-bar .titlebar button.text-button.titlebutton label:first-child, .titlebar .path-bar button.text-button.titlebutton label:first-child, .path-bar button label:first-child {
+.path-bar button.text-button.image-button label:first-child, .path-bar button label:first-child {
   padding-left: 10px; }
 
 .path-bar button.slider-button, .path-bar button:not(.image-button):not(.text-button) {
@@ -1365,9 +1399,9 @@ treeview.view {
     border-style: solid none;
     border-width: 1px;
     border-color: #617251; }
-    treeview.view:drop(active).after {
+    treeview.view.after:drop(active) {
       border-top-style: none; }
-    treeview.view:drop(active).before {
+    treeview.view.before:drop(active) {
       border-bottom-style: none; }
   treeview.view.expander {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
@@ -1460,23 +1494,16 @@ menu,
   border-radius: 0;
   background-color: #ffffff;
   border: 1px solid #BDBDBD; }
-  .csd menu, .csd
-  .menu {
+  .csd menu, .csd .menu {
     padding: 4px 0px;
     border-radius: 2px;
     border: none; }
-  menu separator,
-  .csd menu separator,
-  .menu separator,
-  .csd
-  .menu separator {
+  menu separator, .csd menu separator,
+  .menu separator, .csd .menu separator {
     margin: 2px 0;
     background-color: #DFDFDF; }
-  menu .separator:not(label),
-  .csd menu .separator:not(label),
-  .menu .separator:not(label),
-  .csd
-  .menu .separator:not(label) {
+  menu .separator:not(label), .csd menu .separator:not(label),
+  .menu .separator:not(label), .csd .menu .separator:not(label) {
     color: #ffffff; }
   menu menuitem,
   .menu menuitem {
@@ -1552,8 +1579,7 @@ popover.background {
   background-clip: border-box;
   background-color: #ffffff;
   box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.07); }
-  .csd popover, popover, .csd
-  popover.background,
+  .csd popover, popover, .csd popover.background,
   popover.background {
     border: 1px solid #b0b0b0; }
   popover separator,
@@ -1769,10 +1795,10 @@ scrollbar {
       min-height: 4px;
       background-color: #6a6a6a;
       border: 1px solid rgba(255, 255, 255, 0.6); }
-    scrollbar.overlay-indicator:not(.dragging):not(.hovering).vertical slider {
+    scrollbar.overlay-indicator.vertical:not(.dragging):not(.hovering) slider {
       margin: 2px 0;
       min-height: 40px; }
-    scrollbar.overlay-indicator:not(.dragging):not(.hovering).horizontal slider {
+    scrollbar.overlay-indicator.horizontal:not(.dragging):not(.hovering) slider {
       margin: 0 2px;
       min-width: 40px; }
   scrollbar.overlay-indicator.dragging, scrollbar.overlay-indicator.hovering {
@@ -1808,8 +1834,7 @@ infobar switch {
 
 headerbar switch,
 .primary-toolbar switch,
-.primary-toolbar toolbar switch,
-.primary-toolbar .inline-toolbar switch {
+.primary-toolbar toolbar switch {
   background-image: -gtk-scaled(url("assets/switch-header.png"), url("assets/switch-header@2.png")); }
 
 switch:checked {
@@ -1822,8 +1847,7 @@ infobar switch:checked {
 
 headerbar switch:checked,
 .primary-toolbar switch:checked,
-.primary-toolbar toolbar switch:checked,
-.primary-toolbar .inline-toolbar switch:checked {
+.primary-toolbar toolbar switch:checked {
   background-image: -gtk-scaled(url("assets/switch-active-header.png"), url("assets/switch-active-header@2.png")); }
 
 switch:disabled {
@@ -1836,8 +1860,7 @@ infobar switch:disabled {
 
 headerbar switch:disabled,
 .primary-toolbar switch:disabled,
-.primary-toolbar toolbar switch:disabled,
-.primary-toolbar .inline-toolbar switch:disabled {
+.primary-toolbar toolbar switch:disabled {
   background-image: -gtk-scaled(url("assets/switch-insensitive-header.png"), url("assets/switch-insensitive-header@2.png")); }
 
 switch:checked:disabled {
@@ -1850,8 +1873,7 @@ infobar switch:checked:disabled {
 
 headerbar switch:checked:disabled,
 .primary-toolbar switch:checked:disabled,
-.primary-toolbar toolbar switch:checked:disabled,
-.primary-toolbar .inline-toolbar switch:checked:disabled {
+.primary-toolbar toolbar switch:checked:disabled {
   background-image: -gtk-scaled(url("assets/switch-active-insensitive-header.png"), url("assets/switch-active-insensitive-header@2.png")); }
 
 .check,
@@ -2069,11 +2091,8 @@ radio {
   min-width: 16px;
   min-height: 16px;
   margin: 0 2px; }
-  check:only-child,
-  menu menuitem check,
-  radio:only-child,
-  menu menuitem
-  radio {
+  check:only-child, menu menuitem check,
+  radio:only-child, menu menuitem radio {
     margin: 0; }
 
 scale {
@@ -2119,24 +2138,16 @@ scale {
       .osd scale slider:active {
         background-color: #789d55;
         border-color: #789d55; }
-    menuitem:hover scale slider,
-    row:selected scale slider,
-    infobar scale slider {
+    menuitem:hover scale slider, row:selected scale slider, infobar scale slider {
       background-color: #ffffff;
       border-color: #ffffff; }
-      menuitem:hover scale slider:hover,
-      row:selected scale slider:hover,
-      infobar scale slider:hover {
+      menuitem:hover scale slider:hover, row:selected scale slider:hover, infobar scale slider:hover {
         background-color: #eff4ea;
         border-color: #eff4ea; }
-      menuitem:hover scale slider:active,
-      row:selected scale slider:active,
-      infobar scale slider:active {
+      menuitem:hover scale slider:active, row:selected scale slider:active, infobar scale slider:active {
         background-color: #c9d9b9;
         border-color: #c9d9b9; }
-      menuitem:hover scale slider:disabled,
-      row:selected scale slider:disabled,
-      infobar scale slider:disabled {
+      menuitem:hover scale slider:disabled, row:selected scale slider:disabled, infobar scale slider:disabled {
         background-color: #ceddc0;
         border-color: #ceddc0; }
   scale trough {
@@ -2151,17 +2162,13 @@ scale {
       outline-color: rgba(219, 219, 219, 0.2); }
       .osd scale trough highlight {
         background-color: #92b372; }
-    menuitem:hover scale trough row:selected scale trough,
-    infobar scale trough {
+    menuitem:hover scale trough row:selected scale trough, infobar scale trough {
       background-color: rgba(0, 0, 0, 0.2); }
-      menuitem:hover scale trough row:selected scale trough highlight,
-      infobar scale trough highlight {
+      menuitem:hover scale trough row:selected scale trough highlight, infobar scale trough highlight {
         background-color: #ffffff; }
-        menuitem:hover scale trough row:selected scale trough highlight:disabled,
-        infobar scale trough highlight:disabled {
+        menuitem:hover scale trough row:selected scale trough highlight:disabled, infobar scale trough highlight:disabled {
           background-color: #ceddc0; }
-      menuitem:hover scale trough row:selected scale trough:disabled,
-      infobar scale trough:disabled {
+      menuitem:hover scale trough row:selected scale trough:disabled, infobar scale trough:disabled {
         background-color: rgba(0, 0, 0, 0.1); }
   scale highlight {
     border-radius: 2.5px;
@@ -2228,15 +2235,13 @@ progressbar {
     background-color: #92b372;
     border-radius: 0px;
     box-shadow: none; }
-    row:selected progressbar progress,
-    infobar progressbar progress {
+    row:selected progressbar progress, infobar progressbar progress {
       background-color: #ffffff; }
   progressbar trough {
     border: 1px solid #BDBDBD;
     border-radius: 2px;
     background-color: #ffffff; }
-    row:selected progressbar trough,
-    infobar progressbar trough {
+    row:selected progressbar trough, infobar progressbar trough {
       background-color: rgba(0, 0, 0, 0.2); }
 
 .osd .progressbar {
@@ -2408,7 +2413,7 @@ row.activatable:disabled {
 row.activatable:selected:active {
   color: #ffffff; }
 
-row.activatable:selected.has-open-popup, row.activatable:selected:hover {
+row.activatable.has-open-popup:selected, row.activatable:selected:hover {
   background-color: #83a167; }
 
 .app-notification {
@@ -2529,13 +2534,10 @@ filechooserbutton:drop(active) {
 .sidebar {
   border-style: none;
   background-color: whitesmoke; }
-  stacksidebar.sidebar:dir(ltr) list,
-  stacksidebar.sidebar.left list,
-  stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left, .sidebar.left:dir(rtl) {
+  stacksidebar.sidebar:dir(ltr) list, stacksidebar.sidebar.left list, stacksidebar.sidebar.left:dir(rtl) list, .sidebar:dir(ltr), .sidebar.left {
     border-right: 1px solid #BDBDBD;
     border-left-style: none; }
-  stacksidebar.sidebar:dir(rtl) list,
-  stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
+  stacksidebar.sidebar:dir(rtl) list, stacksidebar.sidebar.right list, .sidebar:dir(rtl), .sidebar.right {
     border-left: 1px solid #BDBDBD;
     border-right-style: none; }
   .sidebar list {
@@ -2553,7 +2555,7 @@ stacksidebar row {
     background-size: 70px;
     background-position: 4px;
     background-repeat: no-repeat; }
-  stacksidebar row.activatable:selected.needs-attention {
+  stacksidebar row.activatable.needs-attention:selected {
     background-image: radial-gradient(circle closest-side at 5% 25%, #ffffff 0%, #ffffff 100%, transparent 100%);
     background-size: 70px;
     background-position: 4px;
@@ -2672,7 +2674,8 @@ infobar {
   infobar.question {
     background-color: #55c1ec; }
 
-.primary-toolbar toolbar.selection-mode button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover, .selection-mode.primary-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
+.primary-toolbar toolbar.selection-mode button:hover,
+.selection-mode.primary-toolbar button:hover, .primary-toolbar .selection-mode.inline-toolbar button:hover, headerbar.selection-mode button:hover, row:selected button, infobar.info button, infobar.question button, infobar.warning button, infobar.error button {
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0);
   border-color: rgba(255, 255, 255, 0.5); }
@@ -2683,7 +2686,9 @@ row:selected button.flat, infobar.info button.flat, infobar.question button.flat
   background-image: none;
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0); }
-  .primary-toolbar toolbar.selection-mode button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, .selection-mode.primary-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, .selection-mode.primary-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
+  .primary-toolbar toolbar.selection-mode button:disabled,
+  .selection-mode.primary-toolbar button:disabled, .primary-toolbar .selection-mode.inline-toolbar button:disabled, headerbar.selection-mode button:disabled, .primary-toolbar toolbar.selection-mode button:disabled label,
+  .selection-mode.primary-toolbar button:disabled label, .primary-toolbar .selection-mode.inline-toolbar button:disabled label, headerbar.selection-mode button:disabled label, row:selected button.flat:disabled, infobar.info button.flat:disabled, infobar.question button.flat:disabled, infobar.warning button.flat:disabled, infobar.error button.flat:disabled, row:selected button.flat:disabled label, infobar.info button.flat:disabled label, infobar.question button.flat:disabled label, infobar.warning button.flat:disabled label, infobar.error button.flat:disabled label {
     color: rgba(255, 255, 255, 0.4); }
 
 row:selected button:hover, infobar.info button:hover, infobar.question button:hover, infobar.warning button:hover, infobar.error button:hover {
@@ -2691,7 +2696,9 @@ row:selected button:hover, infobar.info button:hover, infobar.question button:ho
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.8); }
 
-.primary-toolbar toolbar.selection-mode button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, .selection-mode.primary-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, .selection-mode.primary-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:active:hover, infobar.info button:active:hover, infobar.question button:active:hover, infobar.warning button:active:hover, infobar.error button:active:hover, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
+.primary-toolbar toolbar.selection-mode button:active,
+.selection-mode.primary-toolbar button:active, .primary-toolbar .selection-mode.inline-toolbar button:active, headerbar.selection-mode button:active, .primary-toolbar toolbar.selection-mode button:checked,
+.selection-mode.primary-toolbar button:checked, .primary-toolbar .selection-mode.inline-toolbar button:checked, headerbar.selection-mode button:checked, row:selected button:active, infobar.info button:active, infobar.question button:active, infobar.warning button:active, infobar.error button:active, row:selected button:checked, infobar.info button:checked, infobar.question button:checked, infobar.warning button:checked, infobar.error button:checked {
   color: #92b372;
   background-color: #ffffff;
   border-color: #ffffff; }
@@ -2701,7 +2708,9 @@ row:selected button:disabled, infobar.info button:disabled, infobar.question but
   border-color: rgba(255, 255, 255, 0.4); }
   row:selected button:disabled, infobar.info button:disabled, infobar.question button:disabled, infobar.warning button:disabled, infobar.error button:disabled, row:selected button:disabled label, infobar.info button:disabled label, infobar.question button:disabled label, infobar.warning button:disabled label, infobar.error button:disabled label {
     color: rgba(255, 255, 255, 0.5); }
-  .primary-toolbar toolbar.selection-mode button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, .selection-mode.primary-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, .selection-mode.primary-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
+  .primary-toolbar toolbar.selection-mode button:disabled:checked,
+  .selection-mode.primary-toolbar button:disabled:checked, .primary-toolbar .selection-mode.inline-toolbar button:disabled:checked, headerbar.selection-mode button:disabled:checked, .primary-toolbar toolbar.selection-mode button:disabled:active,
+  .selection-mode.primary-toolbar button:disabled:active, .primary-toolbar .selection-mode.inline-toolbar button:disabled:active, headerbar.selection-mode button:disabled:active, row:selected button:disabled:active, infobar.info button:disabled:active, infobar.question button:disabled:active, infobar.warning button:disabled:active, infobar.error button:disabled:active, row:selected button:disabled:checked, infobar.info button:disabled:checked, infobar.question button:disabled:checked, infobar.warning button:disabled:checked, infobar.error button:disabled:checked {
     color: #92b372;
     background-color: rgba(255, 255, 255, 0.5);
     border-color: rgba(255, 255, 255, 0.4); }
@@ -2860,8 +2869,7 @@ decoration {
   margin: 10px; }
   decoration:backdrop {
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15), 0 8px 8px 0 transparent, 0 5px 5px 0 rgba(0, 0, 0, 0.25); }
-  .fullscreen decoration,
-  .tiled decoration {
+  .fullscreen decoration, .tiled decoration {
     border-radius: 0; }
   .popup decoration {
     box-shadow: none;
@@ -2964,42 +2972,52 @@ headerbar button.titlebutton,
   .titlebar button.titlebutton.minimize:active {
     background-image: -gtk-scaled(url("assets/titlebutton-min-active.png"), url("assets/titlebutton-min-active@2.png")); }
 
-.view:selected, iconview:selected, .view:selected:focus, .view text:selected, iconview text:selected,
-textview text:selected, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
-textview text selection:focus,
-textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
-modelbutton.flat:active,
-modelbutton.flat:active arrow,
-modelbutton.flat:selected,
-modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+.caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
 filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
 filechooser placessidebar.sidebar list row.sidebar-row:selected,
 filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
-filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .view:selected, .view:selected:focus,
+.view text:selected,
+textview text:selected,
+.view text:selected:focus,
+textview text:selected:focus, .view text selection:focus, .view text selection,
+textview text selection:focus,
+textview text selection, iconview:selected, iconview:selected:focus, iconview text selection:focus, .view text selection, iconview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+modelbutton.flat:active,
+modelbutton.flat:active arrow,
+modelbutton.flat:selected,
+modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected {
   background-color: #92b372; }
-  row:selected label, label:selected, .view:selected, iconview:selected, .view:selected:focus, .view text:selected, iconview text:selected,
-  textview text:selected, .view text selection:focus, iconview text selection:focus, .view text selection, iconview text selection,
-  textview text selection:focus,
-  textview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
-  modelbutton.flat:active,
-  modelbutton.flat:active arrow,
-  modelbutton.flat:selected,
-  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
+  row:selected label, label:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover,
   filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected,
   filechooser placessidebar.sidebar list row.sidebar-row:selected,
   filechooser placessidebar.sidebar list row.sidebar-row:selected:hover,
-  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .nemo-window .nemo-window-pane widget.entry:selected:focus, .nemo-window .nemo-window-pane widget.entry:selected, .nemo-window .nemo-inactive-pane .view:selected:focus, .nemo-window .nemo-inactive-pane iconview:selected:focus, .nemo-window .nemo-inactive-pane .view:selected, .nemo-window .nemo-inactive-pane iconview:selected, .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+  filechooser placessidebar.sidebar list row.sidebar-row:active:hover, .view:selected, .view:selected:focus,
+  .view text:selected,
+  textview text:selected,
+  .view text:selected:focus,
+  textview text:selected:focus, .view text selection:focus, .view text selection,
+  textview text selection:focus,
+  textview text selection, iconview:selected, iconview:selected:focus, iconview text selection:focus, .view text selection, iconview text selection, flowbox flowboxchild:selected, entry selection:focus, entry selection, menuitem.button.flat:active, menuitem.button.flat:active arrow, menuitem.button.flat:selected, menuitem.button.flat:selected arrow,
+  modelbutton.flat:active,
+  modelbutton.flat:active arrow,
+  modelbutton.flat:selected,
+  modelbutton.flat:selected arrow, treeview.view:selected, treeview.view:selected:focus, row:selected {
     color: #ffffff; }
-    label:disabled selection, row:selected label:disabled, label:disabled:selected, .view:disabled:selected, iconview:disabled:selected, iconview:disabled:selected:focus, .view text:disabled:selected, iconview text:disabled:selected,
-    textview text:disabled:selected, iconview text:disabled:selected:focus,
-    textview text:disabled:selected:focus, iconview text selection:disabled:focus, .view text selection:disabled, iconview text selection:disabled,
-    textview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
+    label:disabled selection, row:selected label:disabled, label:disabled:selected, .caja-navigation-window .view .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected, .nemo-window .nemo-inactive-pane .view:disabled:selected:focus, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected:hover,
+    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .view:disabled:selected,
+    .view text:disabled:selected,
+    textview text:disabled:selected,
+    textview text:disabled:selected:focus, .view text selection:disabled,
+    textview text selection:disabled:focus,
+    textview text selection:disabled, iconview:disabled:selected, iconview:disabled:selected:focus, iconview text selection:disabled:focus, iconview text selection:disabled, flowbox flowboxchild:disabled:selected, entry selection:disabled, menuitem.button.flat:disabled:active, menuitem.button.flat:active arrow:disabled, menuitem.button.flat:disabled:selected, menuitem.button.flat:selected arrow:disabled,
     modelbutton.flat:disabled:active,
     modelbutton.flat:active arrow:disabled,
     modelbutton.flat:disabled:selected,
-    modelbutton.flat:selected arrow:disabled, treeview.view:disabled:selected:focus, row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:selected, .nautilus-window placessidebar.sidebar list row.sidebar-row:disabled:active:hover,
-    filechooser placessidebar.sidebar list row.sidebar-row:disabled:selected,
-    filechooser placessidebar.sidebar list row.sidebar-row:disabled:active:hover, .nemo-window .nemo-window-pane widget.entry:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected:focus, .nemo-window .nemo-inactive-pane .view:disabled:selected, .nemo-window .nemo-inactive-pane iconview:disabled:selected, .caja-navigation-window .view .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected, .caja-navigation-window iconview .cell:disabled:selected:focus {
+    modelbutton.flat:selected arrow:disabled, row:disabled:selected {
       color: #c9d9b9; }
 
 GeditNotebook.notebook tab.reorderable-page.top:active, GeditNotebook.notebook tab.reorderable-page.top.active-page, GeditNotebook.notebook tab.reorderable-page.top.active-page:hover, GeditNotebook.notebook tab.top:active, GeditNotebook.notebook tab.top.active-page, GeditNotebook.notebook tab.top.active-page:hover,
@@ -3101,10 +3119,9 @@ vte-terminal {
     color: #ffffff; }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
-popover.background label.nautilus-canvas-item.separator,
 .nautilus-list-dim-label {
   color: #909090; }
-  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, .nautilus-canvas-item.dim-label:selected:focus, label.nautilus-canvas-item.separator:selected:focus,
+  .nautilus-canvas-item.dim-label:selected, label.nautilus-canvas-item.separator:selected, .nautilus-canvas-item.dim-label:selected:focus,
   .nautilus-list-dim-label:selected,
   .nautilus-list-dim-label:selected:focus {
     color: #e9f0e3; }
@@ -3137,8 +3154,8 @@ filechooser placessidebar.sidebar list {
     filechooser placessidebar.sidebar list row.sidebar-row:disabled label,
     filechooser placessidebar.sidebar list row.sidebar-row:disabled image {
       color: rgba(219, 219, 219, 0.4); }
-    .nautilus-window placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
-    filechooser placessidebar.sidebar list row.sidebar-row:selected.has-open-popup .sidebar-icon,
+    .nautilus-window placessidebar.sidebar list row.sidebar-row.has-open-popup:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon, .nautilus-window placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon,
+    filechooser placessidebar.sidebar list row.sidebar-row.has-open-popup:selected .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:selected .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:selected:hover .sidebar-icon,
     filechooser placessidebar.sidebar list row.sidebar-row:active:hover .sidebar-icon {
@@ -3252,7 +3269,8 @@ NautilusListView .view, NautilusListView iconview {
   .nemo-window grid > paned > separator {
     background-image: linear-gradient(to bottom, #404040, #404040); }
   .nemo-window widget .toolbar .image-button, .nemo-window widget .toolbar headerbar button.titlebutton, headerbar .nemo-window widget .toolbar button.titlebutton,
-  .nemo-window widget .toolbar .titlebar button.titlebutton, .titlebar .nemo-window widget .toolbar button.titlebutton {
+  .nemo-window widget .toolbar .titlebar button.titlebutton,
+  .titlebar .nemo-window widget .toolbar button.titlebutton {
     padding: 0; }
 
 .caja-navigation-window {
@@ -3260,7 +3278,7 @@ NautilusListView .view, NautilusListView iconview {
    * when split panes are used. Without it the inactive pane isn't displayed
    * properly
    */ }
-  .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus, .caja-navigation-window iconview .cell:selected:focus {
+  .caja-navigation-window .view .cell:selected, .caja-navigation-window iconview .cell:selected, .caja-navigation-window .view .cell:selected:focus {
     background-image: linear-gradient(to bottom, #92b372, #92b372); }
   .caja-navigation-window .caja-side-pane .view, .caja-navigation-window .caja-side-pane iconview,
   .caja-navigation-window .caja-side-pane textview text,
@@ -3359,7 +3377,7 @@ NautilusListView .view, NautilusListView iconview {
   .gedit-map-frame border:dir(rtl) {
     border-right-width: 1px; }
 
-.gedit-search-slider, .xed-window .xed-goto-line-box {
+.xed-window .xed-goto-line-box, .gedit-search-slider {
   background-color: whitesmoke;
   padding: 6px;
   border-color: #BDBDBD;
@@ -3439,8 +3457,7 @@ dockoverlayedge {
   dockoverlayedge docktabstrip {
     padding: 0;
     border: none; }
-  dockoverlayedge.left-edge tab:checked,
-  dockoverlayedge.right-edge tab:checked {
+  dockoverlayedge.left-edge tab:checked, dockoverlayedge.right-edge tab:checked {
     border-width: 1px 0; }
 
 popover.messagepopover.background {
@@ -3668,7 +3685,9 @@ SynapseGuiViewVirgilio *:selected {
     color: #ffffff;
     border: none;
     background-color: #92b372; }
-  .gnome-panel-menu-bar button:not(#tasklist-button) label, .mate-panel-menu-bar button:not(#tasklist-button) label, .xfce4-panel.panel button label, .gnome-panel-menu-bar button:not(#tasklist-button) image, .mate-panel-menu-bar button:not(#tasklist-button) image, .xfce4-panel.panel button image {
+  .gnome-panel-menu-bar button:not(#tasklist-button) label,
+  .mate-panel-menu-bar button:not(#tasklist-button) label, .xfce4-panel.panel button label, .gnome-panel-menu-bar button:not(#tasklist-button) image,
+  .mate-panel-menu-bar button:not(#tasklist-button) image, .xfce4-panel.panel button image {
     color: inherit; }
 
 .floating-bar {
@@ -3733,8 +3752,7 @@ PantheonTerminalPantheonTerminalWindow.background {
   background-color: transparent; }
 
 SwitchboardCategoryView .view:selected, SwitchboardCategoryView iconview:selected,
-SwitchboardCategoryView .view:selected:focus,
-SwitchboardCategoryView iconview:selected:focus {
+SwitchboardCategoryView .view:selected:focus {
   color: #303030; }
 
 .cs-header {
@@ -3762,26 +3780,31 @@ SwitchboardCategoryView iconview:selected:focus {
   padding: 0; }
 
 EvWindow .content-view .view:selected, EvWindow .content-view iconview:selected,
-EvWindow .content-view .view:focus:selected,
-EvWindow .content-view iconview:focus:selected {
+EvWindow .content-view .view:focus:selected {
   background-color: #92b372;
   color: #ffffff; }
 
 .nautilus-window placessidebar.sidebar list scrollbar,
 filechooser placessidebar.sidebar list scrollbar, .nemo-window .sidebar scrollbar {
   border-color: #333333; }
-  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
+  .nautilus-window placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider,
+  filechooser placessidebar.sidebar list scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider, .nemo-window .sidebar scrollbar.overlay-indicator:not(.dragging):not(.hovering) slider {
     background-color: white;
     border: 1px solid rgba(0, 0, 0, 0.3); }
-  .nautilus-window placessidebar.sidebar list scrollbar slider, filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
+  .nautilus-window placessidebar.sidebar list scrollbar slider,
+  filechooser placessidebar.sidebar list scrollbar slider, .nemo-window .sidebar scrollbar slider {
     background-color: rgba(255, 255, 255, 0.7); }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:hover, filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover,
+    filechooser placessidebar.sidebar list scrollbar slider:hover, .nemo-window .sidebar scrollbar slider:hover {
       background-color: white; }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active, filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:hover:active,
+    filechooser placessidebar.sidebar list scrollbar slider:hover:active, .nemo-window .sidebar scrollbar slider:hover:active {
       background-color: #92b372; }
-    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled, filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
+    .nautilus-window placessidebar.sidebar list scrollbar slider:disabled,
+    filechooser placessidebar.sidebar list scrollbar slider:disabled, .nemo-window .sidebar scrollbar slider:disabled {
       background-color: transparent; }
-  .nautilus-window placessidebar.sidebar list scrollbar trough, filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
+  .nautilus-window placessidebar.sidebar list scrollbar trough,
+  filechooser placessidebar.sidebar list scrollbar trough, .nemo-window .sidebar scrollbar trough {
     background-color: #333333; }
 
 .thunar .sidebar .view, .thunar .sidebar iconview {
@@ -4021,3 +4044,108 @@ window.background.lightdm .lightdm-combo {
 @define-color wm_icon_unfocused_bg #B6B8C0;
 @define-color wm_icon_hover_bg #7A7F8B;
 @define-color wm_icon_active_bg #ffffff;
+/* Based on _Adwaita-base.scss from libhandy */
+popover.combo {
+  padding: 0; }
+  popover.combo list {
+    background-color: transparent; }
+    popover.combo list > row {
+      padding: 0 10px;
+      min-height: 50px; }
+
+row.expander {
+  padding: 0px; }
+  row.expander:checked image.expander-row-arrow:not(:disabled) {
+    color: #92b372; }
+  row.expander image.expander-row-arrow:disabled {
+    color: rgba(48, 48, 48, 0.55); }
+
+keypad .digit {
+  font-size: 200%;
+  font-weight: bold; }
+
+keypad .letters {
+  font-size: 70%; }
+
+keypad .symbol {
+  font-size: 160%; }
+
+viewswitcher, viewswitcher button {
+  margin: 0;
+  padding: 0; }
+
+viewswitcher button {
+  border-radius: 0;
+  border-top: 0;
+  border-bottom: 0; }
+  viewswitcher button:not(:checked):not(:hover) {
+    background: transparent;
+    border-color: transparent; }
+  viewswitcher button:checked, viewswitcher button:active {
+    border-color: #92b372; }
+  viewswitcher button > stack > box.narrow {
+    font-size: 0.75rem;
+    padding-top: 7px;
+    padding-bottom: 5px; }
+    viewswitcher button > stack > box.narrow image,
+    viewswitcher button > stack > box.narrow label {
+      padding-left: 8px;
+      padding-right: 8px; }
+  viewswitcher button > stack > box.wide {
+    padding: 8px 10px; }
+    viewswitcher button > stack > box.wide label:dir(ltr) {
+      padding-right: 7px; }
+    viewswitcher button > stack > box.wide label:dir(rtl) {
+      padding-left: 7px; }
+  viewswitcher button.needs-attention > stack > box label {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#92b372), to(transparent));
+    background-size: 6px 6px;
+    background-repeat: no-repeat;
+    background-position: right 0px; }
+    viewswitcher button.needs-attention > stack > box label:dir(rtl) {
+      background-position: left 0px; }
+  viewswitcher button.needs-attention:active > stack > box label {
+    background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to(#ffffff), to(transparent)); }
+
+viewswitcherbar actionbar > revealer > box {
+  padding: 0; }
+
+list.content,
+list.content list {
+  background-color: transparent; }
+
+list.content list.nested > row:not(:active):not(:hover):not(:selected), list.content list.nested > row:not(:active):hover:not(.activatable):not(:selected) {
+  background-color: #f8f8f8; }
+
+list.content list.nested > row.activatable:not(:active):hover:not(:selected) {
+  background-color: #f2f2f2; }
+
+list.content > row:not(.expander):not(:active):not(:hover):not(:selected), list.content > row:not(.expander):not(:active):hover:not(.activatable):not(:selected), list.content > row.expander row.header:not(:active):not(:hover):not(:selected), list.content > row.expander row.header:not(:active):hover:not(.activatable):not(:selected) {
+  background-color: #ffffff; }
+
+list.content > row.activatable:not(.expander):not(:active):hover:not(:selected), list.content > row.expander row.header.activatable:not(:active):hover:not(:selected) {
+  background-color: #f2f2f2; }
+
+list.content > row,
+list.content > row list > row {
+  border-color: #BDBDBD;
+  border-style: solid;
+  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+
+list.content > row:not(:last-child) {
+  border-width: 1px 1px 0px 1px; }
+
+list.content > row:last-child, list.content > row.checked-expander-row-previous-sibling, list.content > row.expander:checked {
+  border-width: 1px; }
+
+list.content > row.expander:checked:not(:first-child), list.content > row.expander:checked + row {
+  margin-top: 5px; }
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized),
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration,
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) > decoration-overlay {
+  border-radius: 3px; }
+
+.windowhandle separator.sidebar:dir(ltr), .windowhandle separator.sidebar.left, .windowhandle separator.sidebar.left:dir(rtl), .windowhandle separator.sidebar:dir(rtl), .windowhandle separator.sidebar.right {
+  background-color: #BDBDBD;
+  margin: 0; }

--- a/src/Mint-Y/gtk-3.0/sass/_libhandy.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_libhandy.scss
@@ -1,0 +1,238 @@
+/* Based on _Adwaita-base.scss from libhandy */
+
+// HdyComboRow
+
+popover.combo {
+  padding: 0;
+
+  list {
+    background-color: transparent;
+
+    > row {
+      padding: 0 10px;
+      min-height: 50px;
+
+      &:first-child { @extend %linked_vertical_top; }
+      &:last-child { @extend %linked_vertical_bottom; }
+    }
+  }
+
+  overshoot.top { @extend %linked_vertical_top; }
+  overshoot.bottom { @extend %linked_vertical_bottom; }
+
+  scrollbar.vertical {
+    //background-color: $_popover_bg;
+
+    &:dir(ltr) { @extend %linked_right; }
+    &:dir(rtl) { @extend %linked_left; }
+  }
+}
+
+// HdyExpanderRow
+
+row.expander {
+  padding: 0px;
+
+  &:checked image.expander-row-arrow:not(:disabled) {
+    color: $selected_bg_color;
+  }
+
+  image.expander-row-arrow:disabled {
+    color: $insensitive_fg_color;
+  }
+}
+
+// HdyKeypad
+
+keypad {
+  .digit {
+    font-size: 200%;
+    font-weight: bold;
+  }
+
+  .letters {
+    font-size: 70%;
+  }
+
+  .symbol {
+    font-size: 160%;
+  }
+}
+
+// HdyViewSwitcher
+
+viewswitcher {
+  &, & button {
+    margin: 0;
+    padding: 0;
+  }
+
+  button {
+    border-radius: 0;
+    border-top: 0;
+    border-bottom: 0;
+
+    &:not(:checked):not(:hover) {
+      background: transparent;
+      border-color: transparent;
+    }
+
+    &:checked, &:active {
+      border-color: $selected_bg_color;
+    }
+
+    // View switcher button
+    > stack > box {
+      &.narrow {
+        font-size: 0.75rem;
+        padding-top: 7px;
+        padding-bottom: 5px;
+
+        image,
+        label {
+          padding-left: 8px;
+          padding-right: 8px;
+        }
+      }
+
+      &.wide {
+        padding: 8px 10px;
+
+        label {
+          &:dir(ltr) {
+            padding-right: 7px;
+          }
+
+          &:dir(rtl) {
+            padding-left: 7px;
+          }
+        }
+      }
+    }
+
+    &.needs-attention {
+      > stack > box label {
+        background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to($selected_bg_color), to(transparent));
+        background-size: 6px 6px;
+        background-repeat: no-repeat;
+        background-position: right 0px;
+
+        &:dir(rtl) {
+          background-position: left 0px;
+        }
+      }
+
+      &:active > stack > box label {
+        background-image: -gtk-gradient(radial, center center, 0, center center, 0.5, to($selected_fg_color), to(transparent));
+      }
+    }
+  }
+}
+
+// HdyViewSwitcherBar
+
+viewswitcherbar actionbar > revealer > box {
+  padding: 0;
+}
+
+// Content list
+
+list.content {
+  &,
+  list {
+    background-color: transparent;
+  }
+
+  // Nested rows background
+  list.nested > row:not(:active) {
+    &:not(:hover):not(:selected),
+    &:hover:not(.activatable):not(:selected) {
+      background-color: mix($bg_color, $base_color);
+    }
+
+    &:hover.activatable:not(:selected) {
+      background-color: if($variant != 'dark', mix($base_color, black, 95%), mix($base_color, white, 97%));
+    }
+  }
+
+  > row {
+    // Regular rows and expander header rows background
+    &:not(.expander):not(:active):not(:hover):not(:selected),
+    &:not(.expander):not(:active):hover:not(.activatable):not(:selected),
+    &.expander row.header:not(:active):not(:hover):not(:selected),
+    &.expander row.header:not(:active):hover:not(.activatable):not(:selected) {
+      background-color: $base_color;
+    }
+
+    &:not(.expander):not(:active):hover.activatable:not(:selected),
+    &.expander row.header:not(:active):hover.activatable:not(:selected) {
+      background-color: if($variant != 'dark', mix($base_color, black, 95%), mix($base_color, white, 97%));
+    }
+
+    &,
+    list > row {
+      border-color: $borders_color;
+      border-style: solid;
+      transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    }
+
+    // Top border
+    &:not(:last-child) {
+      border-width: 1px 1px 0px 1px;
+    }
+
+    // Rounded top
+    &:first-child,
+    &.expander:first-child row.header,
+    &.expander:checked,
+    &.expander:checked row.header,
+    &.expander:checked + row,
+    &.expander:checked + row.expander row.header {
+      @extend %linked_vertical_top;
+    }
+
+    // Bottom border
+    &:last-child,
+    &.checked-expander-row-previous-sibling,
+    &.expander:checked {
+      border-width: 1px;
+    }
+
+    // Rounded bottom
+    &:last-child,
+    &.checked-expander-row-previous-sibling,
+    &.expander:checked,
+    &.expander:not(:checked):last-child row.header,
+    &.expander:not(:checked).checked-expander-row-previous-sibling row.header,
+    &.expander.empty:checked row.header,
+    &.expander list.nested > row:last-child {
+      @extend %linked_vertical_bottom;
+    }
+
+    // Add space around expanded rows
+    &.expander:checked:not(:first-child),
+    &.expander:checked + row {
+      margin-top: 5px;
+    }
+  }
+}
+
+// Unified window
+
+window.csd.unified:not(.solid-csd):not(.fullscreen):not(.tiled):not(.tiled-top):not(.tiled-bottom):not(.tiled-left):not(.tiled-right):not(.maximized) {
+  &,
+  > decoration,
+  > decoration-overlay {
+    border-radius: 3px;
+  }
+}
+
+// HdyWindowHandle separator
+
+.windowhandle separator.sidebar {
+  &:dir(ltr), &.left, &.left:dir(rtl),
+  &:dir(rtl), &.right {
+    background-color: $header_border;
+    margin: 0;
+  }
+}

--- a/src/Mint-Y/gtk-3.0/sass/gtk-dark.scss
+++ b/src/Mint-Y/gtk-3.0/sass/gtk-dark.scss
@@ -7,3 +7,4 @@ $darker: 'false';
 @import 'applications';
 @import 'lightdm';
 @import 'colors-public';
+@import 'libhandy';

--- a/src/Mint-Y/gtk-3.0/sass/gtk-darker.scss
+++ b/src/Mint-Y/gtk-3.0/sass/gtk-darker.scss
@@ -7,3 +7,4 @@ $darker: 'true';
 @import 'applications';
 @import 'lightdm';
 @import 'colors-public';
+@import 'libhandy';

--- a/src/Mint-Y/gtk-3.0/sass/gtk.scss
+++ b/src/Mint-Y/gtk-3.0/sass/gtk.scss
@@ -8,3 +8,4 @@ $darker: 'false';
 @import 'lightdm';
 @import 'ubiquity';
 @import 'colors-public';
+@import 'libhandy';


### PR DESCRIPTION
I copied the [_libhandy.scss](https://github.com/jnsh/arc-theme/blob/master/common/gtk-3.0/3.24/sass/_libhandy.scss) from Arc theme, and was able to fix #313 for Mint-Y after slight modification to its variable names. Then I generated the .css files with the shell script.

Mint-X does not use scss, and I could not fix it there, but at least, it is fixed in Mint-Y (and all its variants), and I did not notice any regression.

**Before** (too broad headerbar for apps with libhandy1)
![before](https://user-images.githubusercontent.com/3063132/118600860-2f067e00-b7cf-11eb-9512-d7bd9ebabfaa.png)


**After** (notice the lean headerbar - its size is now same as other apps which use CSD but not libhandy1)
![Screenshot_2021-05-18_11-34-57](https://user-images.githubusercontent.com/3063132/118600875-33cb3200-b7cf-11eb-8b6b-e662ebb5958c.png)
The size of the headerbar is now same as in Arc theme and also Adwaita.


