### PR TITLE
Cinnamon Desktop: dark variant should get the same selected-background-color as the other GTK Controls

### DIFF
--- a/src/Mint-Y/cinnamon/sass/_colors.scss
+++ b/src/Mint-Y/cinnamon/sass/_colors.scss
@@ -3,7 +3,7 @@
 
 // We need to set this first because we use it to tint many
 // of the remaining colors
-$selected_bg_color: #92b372;
+$selected_bg_color: if($variant == 'light', #92b372, #8fa876);
 
 $base_color: if($variant =='light', mix($selected_bg_color, #ffffff, 2%), mix($selected_bg_color, #404040, 2%));
 $text_color: if($variant == 'light', #202020, #D3D3D3);


### PR DESCRIPTION
This is the fix for issue #370