### PR TITLE
Fix for title bar buttons on unfocused windows

### DIFF
--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -3200,23 +3200,24 @@ headerbar,
       color: $selected_fg_color;
       @include draw_circle($selected_bg_color);
 
+      &:backdrop { @include draw-circle($_wm_backdrop_icon_color); }
       &:hover { @include draw-circle(lighten($selected_bg_color, 5%)); }
       &:active { @include draw-circle(darken($selected_bg_color, 5%)); }
-      &:backdrop { @include draw-circle($_wm_backdrop_icon_color); }
     }
 
     &.maximize,
     &.minimize {
+      &:backdrop {
+        color: $_wm_backdrop_icon_color;
+      }
       &:hover,
       &:hover:backdrop {
+        color: $selected_fg_color;
         @include draw-circle($wm_button_hover_bg);
       }
       &:active,
       &:active:backdrop {
         @include draw-circle($wm_button_active_bg);
-      }
-      &:backdrop {
-        color: $_wm_backdrop_icon_color;
       }
     }
   }

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -3212,7 +3212,7 @@ headerbar,
       }
       &:hover,
       &:hover:backdrop {
-        color: $selected_fg_color;
+        color: $fg_color;
         @include draw-circle($wm_button_hover_bg);
       }
       &:active,

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1121,23 +1121,24 @@ windowcontrols {
       }
       @include draw_circle($selected_bg_color);
 
+      &:backdrop { @include draw-circle($_wm_backdrop_icon_color); }
       &:hover { @include draw-circle(lighten($selected_bg_color, 5%)); }
       &:active { @include draw-circle(darken($selected_bg_color, 5%)); }
-      &:backdrop { @include draw-circle($_wm_backdrop_icon_color); }
     }
 
     &.maximize,
     &.minimize {
+      &:backdrop {
+        color: $_wm_backdrop_icon_color;
+      }
       &:hover,
       &:hover:backdrop {
+        color: $selected_fg_color;
         @include draw-circle($wm_button_hover_bg);
       }
       &:active,
       &:active:backdrop {
         @include draw-circle($wm_button_active_bg);
-      }
-      &:backdrop {
-        color: $_wm_backdrop_icon_color;
       }
     }
   }

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1133,7 +1133,7 @@ windowcontrols {
       }
       &:hover,
       &:hover:backdrop {
-        color: $selected_fg_color;
+        color: $fg_color;
         @include draw-circle($wm_button_hover_bg);
       }
       &:active,


### PR DESCRIPTION
This PR addresses 2 issues:
1. In contrast to the minimize and maximize buttons, the close button does not react on mouse hover if the window is not focused. This is confusing: the user may think the close button is disabled. The change brings back the behavior from LM 20.3, where the close button changed its background color on hover even if the window is not focused.
![Unbenannt3](https://user-images.githubusercontent.com/17480795/204490575-86f403f0-8f96-4ea5-95d4-cc4bf97cc6c8.png)
![Unbenannt2](https://user-images.githubusercontent.com/17480795/204490586-a662339f-491f-44ce-87a5-36a72b2e8ba8.png)

3. The contrast of the minimize and maximize icon and the background on mouse hover on unfocused windows is poor. The change brings back the behavior from LM 20.3, where the minimize and maximize icon changed its color (to $selected_fg_color) on mouse hover if the window is not focused.
![Bildschirmfoto vom 2022-11-28 23-06-16](https://user-images.githubusercontent.com/17480795/204488725-1b7ef9b8-5608-494a-8923-0c5ec2f04a22.png)
![Unbenannt](https://user-images.githubusercontent.com/17480795/204489497-691fa036-f58a-4d66-855e-75a17ec0f462.png)
