### PR TITLE
Fix header bar size, e.g. for disk tool

### DIFF
--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -917,7 +917,7 @@ actionbar {
 //
 headerbar,
 %titlebar {
-  min-height: 42px;
+  min-height: 46px;
   padding: 0 7px;
 
   border-width: 0 0 1px;

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1148,7 +1148,7 @@ windowcontrols {
 //
 headerbar,
 %titlebar {
-  min-height: 42px;
+  min-height: 46px;
   padding: 0 7px;
 
   border-width: 0 0 1px;


### PR DESCRIPTION
The CSD windows title bar has a custom height, resulting in unpleasant side-effects, e.g. in the Gnome Disk Tool:
![disk-toolbar-alignment](https://user-images.githubusercontent.com/17480795/204509835-60af2c46-1d5b-4fc0-afe3-4d585f46b7e2.png)

This change aligns the height of the title bar with the height of the toolbar.