### PR TITLE
Better contrast

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -225,7 +225,7 @@ StScrollBar {
   color: rgba(255, 255, 255, 0.87);
   border: 1px solid #202020;
   border-radius: 3px;
-  background-color: rgba(47, 47, 47, 0.99); }
+  background-color: #1C1C1C; }
   .menu.top {
     border-radius: 0 0 3px 3px; }
   .menu.bottom {

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -614,7 +614,7 @@ StScrollBar {
   padding: .5em;
   min-width: 350px;
   border: 1px solid #202020;
-  background-color: #404040; }
+  background-color: #242424; }
 
 .calendar-events-no-events-button {
   margin: 6px 0 6px 0;

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -257,7 +257,7 @@ StScrollBar {
   border-right-width: 0; }
   .popup-menu-item:active {
     color: #ffffff;
-    background-color: #525352; }
+    background-color: #292929; }
   .popup-menu-item:insensitive {
     color: rgba(255, 255, 255, 0.37);
     background: none; }

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1110,15 +1110,15 @@ StScrollBar {
 .menu-favorites-box {
   padding: 10px;
   transition-duration: 300;
-  background-color: #333333;
-  border: 1px solid #202020; }
+  background-color: #242424;
+  border: 1px solid #191919; }
 
 .menu-favorites-button {
   padding: .9em 1em;
   border: 1px solid rgba(0, 0, 0, 0);
   border-radius: 2px; }
   .menu-favorites-button:hover {
-    background-color: #525352; }
+    background-color: #313131; }
 
 .menu-places-box {
   padding: 10px;

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1336,7 +1336,7 @@ StScrollBar {
       padding-left: 1px; }
   .grouped-window-list-item-box:hover, .grouped-window-list-item-box:focus {
     color: rgba(255, 255, 255, 0.87);
-    background-color: rgba(255, 255, 255, 0.17); }
+    background-color: rgba(255, 255, 255, 0.1); }
   .grouped-window-list-item-box:active, .grouped-window-list-item-box:checked {
     color: rgba(255, 255, 255, 0.87);
     border-color: #35a854; }

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1141,7 +1141,7 @@ StScrollBar {
   .menu-application-button-selected {
     padding: 7px;
     color: #ffffff;
-    background-color: #525352;
+    background-color: #292929;
     border: 1px solid #202020; }
     .menu-application-button-selected:highlighted {
       font-weight: bold; }
@@ -1156,7 +1156,7 @@ StScrollBar {
   .menu-category-button-selected {
     padding: 7px;
     color: #ffffff;
-    background-color: #525352;
+    background-color: #292929;
     border: 1px solid #202020; }
   .menu-category-button-hover {
     background-color: red;

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -452,7 +452,7 @@ StScrollBar {
 .panel-top, .panel-bottom, .panel-left, .panel-right {
   color: #ffffff;
   border: none;
-  background-color: rgba(47, 47, 47, 0.99);
+  background-color: #1C1C1C;
   font-size: 1em;
   padding: 0px; }
 

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -48,12 +48,12 @@ stage {
   transition-duration: 300ms;
   border-radius: 3px;
   color: #D3D3D3;
-  background-color: #404040;
+  background-color: #202020;
   border: 1px solid #202020;
   box-shadow: inset 0 2px 4px rgba(64, 64, 64, 0.05); }
   #menu-search-entry:focus, .popup-menu #notification StEntry:focus, #menu-search-entry:hover, .popup-menu #notification StEntry:hover {
     color: rgba(255, 255, 255, 0.87);
-    background-color: #404040;
+    background-color: #202020;
     border: 1px solid #35a854;
     box-shadow: inset 0 2px 4px rgba(64, 64, 64, 0.05); }
   #menu-search-entry:insensitive, .popup-menu #notification StEntry:insensitive {

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1651,11 +1651,11 @@ StScrollBar {
 
 .applet-cornerbar {
   width: 8px;
-  background-color: rgba(255, 255, 255, 0.12); }
+  background-color: rgba(255, 255, 255, 0.1); }
   .applet-cornerbar-box {
     padding: 4px 4px; }
     .applet-cornerbar-box:hover > .applet-cornerbar {
-      background-color: rgba(255, 255, 255, 0.22); }
+      background-color: rgba(255, 255, 255, 0.17); }
   .applet-cornerbar.vertical {
     height: 8px; }
 

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1616,7 +1616,7 @@ StScrollBar {
     padding-bottom: 3px; }
   .applet-box:hover, .applet-box:checked {
     color: #ffffff;
-    background-color: #525352; }
+    background-color: #292929; }
   .applet-box:highlight {
     background-image: none;
     border-image: none;

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1370,7 +1370,7 @@ StScrollBar {
 .grouped-window-list-thumbnail-menu {
   color: rgba(255, 255, 255, 0.87);
   border: 1px solid #202020;
-  background-color: #2f2f2f;
+  background-color: #242424;
   border-radius: 3px;
   padding: 0px; }
   .grouped-window-list-thumbnail-menu > StBoxLayout {


### PR DESCRIPTION
Cinnamon's dark theme has little contrast and is very gray (Linux Mint as a whole uses a lot of gray and I've already mentioned this here before), it should be a little darker. In this pull request I changed the black tones to something more like the black theme in Windows 10 and 11. Microsoft paid a lot of designers just to decide which tone of black and white to use, I think it's a good copy and paste of the hex code color.
![vmplayer_H6AMHQvACF](https://user-images.githubusercontent.com/31783838/226064358-db138bc7-5a1a-4406-8b65-40b6714ee8ce.png)

Current theme:
![vmplayer_m92xpfykbz](https://user-images.githubusercontent.com/31783838/226064366-1477852d-701c-4a08-a9b3-00332f7fa6b8.png)
