### PR TITLE
Mint-Y cinnamon - Add support for .menu-category-button:hover

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1158,9 +1158,10 @@ StScrollBar {
     color: #ffffff;
     background-color: #525352;
     border: 1px solid #202020; }
-  .menu-category-button-hover {
-    background-color: red;
-    border-radius: 2px; }
+  .menu-category-button:hover {
+    background-color: rgba(128, 128, 128, 0.19);
+    border: 1px solid #2f2f2f;
+    border-radius: 0px; }
   .menu-category-button-greyed {
     padding: 7px;
     color: rgba(255, 255, 255, 0.32);

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1159,7 +1159,7 @@ StScrollBar {
     background-color: #525352;
     border: 1px solid #202020; }
   .menu-category-button:hover {
-    background-color: rgba(128, 128, 128, 0.19);
+    background-color: rgba(132, 132, 132, 0.14);
     border: 1px solid #2f2f2f;
     border-radius: 0px; }
   .menu-category-button-greyed {

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1158,9 +1158,10 @@ StScrollBar {
     color: #303030;
     background-color: #c0c0c0;
     border: 1px solid #b5b5b5; }
-  .menu-category-button-hover {
-    background-color: red;
-    border-radius: 2px; }
+  .menu-category-button:hover {
+    background-color: rgba(128, 128, 128, 0.19);
+    border: 1px solid rgba(128, 128, 128, 0.1);
+    border-radius: 0px; }
   .menu-category-button-greyed {
     padding: 7px;
     color: rgba(48, 48, 48, 0.55);

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1159,8 +1159,8 @@ StScrollBar {
     background-color: #c0c0c0;
     border: 1px solid #b5b5b5; }
   .menu-category-button:hover {
-    background-color: rgba(128, 128, 128, 0.19);
-    border: 1px solid rgba(128, 128, 128, 0.1);
+    background-color: rgba(132, 132, 132, 0.14);
+    border: 1px solid rgba(128, 128, 128, 0.07);
     border-radius: 0px; }
   .menu-category-button-greyed {
     padding: 7px;

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1473,9 +1473,10 @@ StScrollBar {
       background-color: $noaccent_selected_bg_color;
       border: 1px solid $borders_color;
     }
-    &-hover {
-      background-color: red;
-      border-radius: 2px;
+    &:hover {
+      background-color: rgba(128,128,128,0.19);
+      border: 1px solid if($variant=='light', rgba(128,128,128,0.1), $bg_color);
+      border-radius: 0px;
     }
     &-greyed {
       padding: 7px;

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1475,7 +1475,7 @@ StScrollBar {
     }
     &:hover {
       background-color: rgba(132,132,132,0.14);
-      border: 1px solid if($variant=='light', rgba(128,128,128,0.1), $bg_color);
+      border: 1px solid if($variant=='light', rgba(128,128,128,0.07), $bg_color);
       border-radius: 0px;
     }
     &-greyed {

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1474,7 +1474,7 @@ StScrollBar {
       border: 1px solid $borders_color;
     }
     &:hover {
-      background-color: rgba(128,128,128,0.19);
+      background-color: rgba(132,132,132,0.14);
       border: 1px solid if($variant=='light', rgba(128,128,128,0.1), $bg_color);
       border-radius: 0px;
     }


### PR DESCRIPTION
Add initial support for .menu-category-button:hover (https://github.com/linuxmint/cinnamon/pull/11473)

![Screenshot from 2023-03-22 16-00-05](https://user-images.githubusercontent.com/58893963/226966101-3010d2fc-162d-4101-a441-34b86880ce47.png)
![Screenshot from 2023-03-22 16-01-15](https://user-images.githubusercontent.com/58893963/226966116-d9bac708-437c-41c1-9489-0aa4713cdea7.png)
