### PR TITLE
Mint-Y cinnamon - Add support for .menu-category-button:hover

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1158,9 +1158,10 @@ StScrollBar {
     color: #ffffff;
     background-color: #525352;
     border: 1px solid #202020; }
-  .menu-category-button-hover {
-    background-color: red;
-    border-radius: 2px; }
+  .menu-category-button:hover {
+    background-color: #3d3d3d;
+    border: 1px solid #292929;
+    border-radius: 0px; }
   .menu-category-button-greyed {
     padding: 7px;
     color: rgba(255, 255, 255, 0.32);

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1158,9 +1158,10 @@ StScrollBar {
     color: #303030;
     background-color: #c0c0c0;
     border: 1px solid #b5b5b5; }
-  .menu-category-button-hover {
-    background-color: red;
-    border-radius: 2px; }
+  .menu-category-button:hover {
+    background-color: #d8d8d8;
+    border: 1px solid #d4d4d4;
+    border-radius: 0px; }
   .menu-category-button-greyed {
     padding: 7px;
     color: rgba(48, 48, 48, 0.55);

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1473,9 +1473,10 @@ StScrollBar {
       background-color: $noaccent_selected_bg_color;
       border: 1px solid $borders_color;
     }
-    &-hover {
-      background-color: red;
-      border-radius: 2px;
+    &:hover {
+      background-color: mix($noaccent_selected_bg_color, $bg_color, 40%);
+      border: 1px solid mix($borders_color, $bg_color, 40%);
+      border-radius: 0px;
     }
     &-greyed {
       padding: 7px;


### PR DESCRIPTION
Add initial support for .menu-category-button:hover (https://github.com/linuxmint/cinnamon/pull/11473)

![Screenshot from 2023-03-30 22-17-20](https://user-images.githubusercontent.com/58893963/228967234-9a487427-c65e-4555-8c15-88acfeddabb7.png)
![Screenshot from 2023-03-30 22-17-48](https://user-images.githubusercontent.com/58893963/228967238-387cc6f4-63bc-4b50-950f-817cdf2f9684.png)
