### PR TITLE
Mint-Y Cinnamon theme - sound applet - use ems instead of px for overlay.

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1462,7 +1462,7 @@ StScrollBar {
 
 .sound-player-overlay {
   width: 290px;
-  height: 70px;
+  height: 5.4em;
   padding: 15px;
   spacing: 0.5em;
   background: rgba(47, 47, 47, 0.9);

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1462,7 +1462,7 @@ StScrollBar {
 
 .sound-player-overlay {
   width: 290px;
-  height: 70px;
+  height: 5.4em;
   padding: 15px;
   spacing: 0.5em;
   background: rgba(232, 232, 232, 0.9);

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1884,7 +1884,7 @@ StScrollBar {
 
   &-overlay {
     width: 290px;
-    height: 70px;
+    height: 5.4em;
     padding: 15px;
     spacing: 0.5em;
     background: transparentize($bg_color, 0.1);


### PR DESCRIPTION
to allow for different default font sizes and text scaling. fixes https://github.com/linuxmint/cinnamon-spices-applets/issues/4781

fixes: https://github.com/linuxmint/cinnamon/issues/11572

I've set the ems value so that the applet looks the same as before with the default ubuntu regular 10 font in mint 21.1.