### PR TITLE
Mint-X cinnamon theme - sound applet. Use ems instead of px for overlay height.

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1905,7 +1905,7 @@ StScrollBar StButton#vhandle:hover {
 
 .sound-player-overlay {
     width: 300px;
-    height: 70px;
+    height: 5.6em;
     padding: 15px;
     spacing: 0.5em;
     background: rgba(0, 0, 0, 0.8);

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1869,7 +1869,7 @@ StScrollBar StButton#vhandle:hover {
 .sound-player-overlay {
     border-top: 1px solid #c2c2c2;
     width: 300px;
-    height: 70px;
+    height: 5.25em;
     padding: 16px;
     spacing: 0.5em;
     color: #464646;


### PR DESCRIPTION
..to allow for different default font sizes and text scaling.

I've set the ems value so that the applet looks the same as before with the default ubuntu regular 10 font in mint 21.1.

\+ Ditto for cinnamon theme Linux Mint.