### PR TITLE
Adjust Title Bar Padding

### DIFF
--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -3174,8 +3174,6 @@ headerbar,
     padding-bottom: 0px;
     padding-right: 0px;
     padding-left: 0px;
-    min-width: 18px;
-    min-height: 18px;
     margin: 0;
   }
 

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -1026,7 +1026,7 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
-    padding: 0 2px;
+    padding: 0 4px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }
@@ -3174,8 +3174,8 @@ headerbar,
     padding-bottom: 0px;
     padding-right: 0px;
     padding-left: 0px;
-    min-width: 22px;
-    min-height: 22px;
+    min-width: 18px;
+    min-height: 18px;
     margin: 0;
   }
 
@@ -3186,7 +3186,7 @@ headerbar,
     min-height: 18px;
     @extend .image-button;
 
-    padding: 10px 3px;
+    padding: 10px 1px;
     margin: 0;
     transition: none;
 

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -918,7 +918,7 @@ actionbar {
 headerbar,
 %titlebar {
   min-height: 46px;
-  padding: 0 7px;
+  padding: 0 2px;
 
   border-width: 0 0 1px;
   border-style: solid;
@@ -1026,10 +1026,13 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
-    padding: 0 7px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }
+  }
+
+  .csd & {  // bigger padding only in csd windows
+    padding: 0 7px;
   }
 
   .solid-csd & {

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -918,7 +918,7 @@ actionbar {
 headerbar,
 %titlebar {
   min-height: 46px;
-  padding: 0 2px;
+  padding: 0 7px;
 
   border-width: 0 0 1px;
   border-style: solid;
@@ -1026,13 +1026,10 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
+    padding: 0 2px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }
-  }
-
-  .csd & {  // bigger padding only in csd windows
-    padding: 0 7px;
   }
 
   .solid-csd & {

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -918,7 +918,7 @@ actionbar {
 headerbar,
 %titlebar {
   min-height: 46px;
-  padding: 0 7px;
+  padding: 0 6px;
 
   border-width: 0 0 1px;
   border-style: solid;
@@ -1026,7 +1026,7 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
-    padding: 0 4px;
+    padding: 2px 6px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }
@@ -3180,8 +3180,8 @@ headerbar,
   button.titlebutton {
     $_wm_backdrop_icon_color: if($variant == 'light', darken($wm_icon_unfocused_bg, 5%), lighten($wm_icon_unfocused_bg, 5%));
 
-    min-width: 18px;
-    min-height: 18px;
+    min-width: 20px;
+    min-height: 20px;
     @extend .image-button;
 
     padding: 10px 1px;

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1089,8 +1089,8 @@ windowcontrols {
   }
 
   button {
-    min-width: 22px;
-    min-height: 22px;
+    min-width: 20px;
+    min-height: 20px;
     @extend .image-button;
 
     padding: 5px 2px;
@@ -1150,7 +1150,7 @@ windowcontrols {
 headerbar,
 %titlebar {
   min-height: 46px;
-  padding: 0 7px;
+  padding: 0 6px;
 
   border-width: 0 0 1px;
   border-style: solid;
@@ -1196,7 +1196,7 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
-    padding: 0 4px;
+    padding: 2px 6px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1150,7 +1150,7 @@ windowcontrols {
 headerbar,
 %titlebar {
   min-height: 46px;
-  padding: 0 2px;
+  padding: 0 7px;
 
   border-width: 0 0 1px;
   border-style: solid;
@@ -1196,13 +1196,10 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
+    padding: 0 2px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }
-  }
-
-  .csd & {  // bigger padding only in csd windows
-    padding: 0 7px;
   }
 
   .solid-csd & {

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1150,7 +1150,7 @@ windowcontrols {
 headerbar,
 %titlebar {
   min-height: 46px;
-  padding: 0 7px;
+  padding: 0 2px;
 
   border-width: 0 0 1px;
   border-style: solid;
@@ -1196,10 +1196,13 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
-    padding: 0 7px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }
+  }
+
+  .csd & {  // bigger padding only in csd windows
+    padding: 0 7px;
   }
 
   .solid-csd & {

--- a/src/Mint-Y/gtk-4.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_common.scss
@@ -1196,7 +1196,7 @@ headerbar,
 
   &.default-decoration {
     min-height: 28px;
-    padding: 0 2px;
+    padding: 0 4px;
     border-bottom-width: 0;
 
     .maximized & { background-color: opacify($header_bg, 1); }


### PR DESCRIPTION
I'd like to suggest to unify the vertical and horizontal window title bar padding. The different distances from the close button to the top and right border, introduced with Mint 21, doesn't look correct to me even after months working with it.
![new vs old style](https://github.com/linuxmint/mint-themes/assets/17480795/3624ba92-7ccd-4ee3-87d4-164edbee34af)

Other desktop environments also do it like this and I think it looks more pleasant and accurate.
![macos](https://github.com/linuxmint/mint-themes/assets/17480795/8a66ccbc-4b06-4009-8ce9-93f0ebb4f5ca) ![ubuntu](https://github.com/linuxmint/mint-themes/assets/17480795/29175f2d-dc1a-45d8-afbf-bfa1e6707d95)

This change brings back the look from Mint 20.3, which was already perfect from my point of view.