### PR TITLE
Fix text selection on unfocused windows

### DIFF
--- a/src/Mint-Y/gtk-2.0/main.rc
+++ b/src/Mint-Y/gtk-2.0/main.rc
@@ -952,7 +952,6 @@ style "entry" {
   ythickness = 4
 
   base[NORMAL] = @base_color
-  base[ACTIVE] = @base_color
   base[INSENSITIVE] = @insensitive_bg_color
 
   engine "pixmap" {
@@ -982,6 +981,15 @@ style "entry" {
       file = "assets/entry-border-active-bg-solid.png"
       border = { 6, 6, 6, 6 }
       stretch = TRUE
+    }
+
+    image {
+      function = FLAT_BOX
+      detail = "entry_bg"
+      state = ACTIVE
+      overlay_file = "assets/null.png"
+      overlay_border = { 0, 0, 0, 0 }
+      overlay_stretch = TRUE
     }
   }
 }


### PR DESCRIPTION
The current Mint themes in 21 and 21.1 have a major issue: selected text is not visible as soon as the window loses the focus:
![Bildschirmfoto vom 2023-06-02 14-46-51](https://github.com/linuxmint/mint-themes/assets/17480795/9253e2f1-d008-43eb-8127-8d42a89d6a7b)

This fix brings back the behavior of Mint 20.3 where the text selection is visible even if the window is not focused.

The additional `image { ... }` is necessary to keep the white background, otherwise it will look like this:
![Bildschirmfoto vom 2023-06-02 15-45-58](https://github.com/linuxmint/mint-themes/assets/17480795/541ca725-c95d-47aa-98e7-a957629d5d71)

fixes #438 