### PR TITLE
Linux Mint/cinnamon.css: Center text in .applet-box

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -2029,6 +2029,7 @@ StScrollBar StButton#vhandle:hover {
     color: #ccc;
     spacing: 3px;
     text-shadow: black 0px 0px 2px;
+    text-align: center;
 }
 
 .applet-box.vertical {


### PR DESCRIPTION
Similar to linuxmint/cinnamon#11755 