### PR TITLE
Remove height from sound-player-overlay so that text can wrap cleanly

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -1905,7 +1905,6 @@ StScrollBar StButton#vhandle:hover {
 
 .sound-player-overlay {
     width: 300px;
-    height: 5.6em;
     padding: 15px;
     spacing: 0.5em;
     background: rgba(0, 0, 0, 0.8);

--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -1869,7 +1869,6 @@ StScrollBar StButton#vhandle:hover {
 .sound-player-overlay {
     border-top: 1px solid #c2c2c2;
     width: 300px;
-    height: 5.25em;
     padding: 16px;
     spacing: 0.5em;
     color: #464646;

--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1466,7 +1466,6 @@ StScrollBar {
 
 .sound-player-overlay {
   width: 290px;
-  height: 5.4em;
   padding: 15px;
   spacing: 0.5em;
   background: rgba(47, 47, 47, 0.9);

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1466,7 +1466,6 @@ StScrollBar {
 
 .sound-player-overlay {
   width: 290px;
-  height: 5.4em;
   padding: 15px;
   spacing: 0.5em;
   background: rgba(232, 232, 232, 0.9);

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1888,7 +1888,6 @@ StScrollBar {
 
   &-overlay {
     width: 290px;
-    height: 5.4em;
     padding: 15px;
     spacing: 0.5em;
     background: transparentize($bg_color, 0.1);


### PR DESCRIPTION
This is in tandem with linuxmint/cinnamon#11756

Discussion: linuxmint/discussions#79