### PR TITLE
[Next] Adapt nemo desktop item text shadow for brighter wallpapers

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-dark.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-dark.css
@@ -3559,11 +3559,12 @@ popover.emoji-completion .emoji:hover {
 
 .caja-desktop.caja-canvas-item {
   color: #eeeeee;
-  text-shadow: 1px 1px transparent(black, 0.2); }
+  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.95), 0px 0px 2px rgba(0, 0, 0, 0.8); }
   .caja-desktop.caja-canvas-item:selected {
     background-color: rgba(255, 255, 255, 0.8);
     color: #ffffff;
-    box-shadow: none; }
+    box-shadow: none;
+    text-shadow: none; }
 
 .caja-side-pane notebook treeview.view,
 .caja-side-pane notebook textview.view text,
@@ -3651,11 +3652,12 @@ popover.emoji-completion .emoji:hover {
 
 .nemo-desktop .nemo-canvas-item {
   color: #eeeeee;
-  text-shadow: 1px 1px transparent(black, 0.2); }
+  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.95), 0px 0px 2px rgba(0, 0, 0, 0.8); }
   .nemo-desktop .nemo-canvas-item:selected {
     background-color: rgba(255, 255, 255, 0.8);
     color: #ffffff;
-    box-shadow: none; }
+    box-shadow: none;
+    text-shadow: none; }
 
 /**********
  * Panels *

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk.css
@@ -3568,11 +3568,12 @@ popover.emoji-completion .emoji:hover {
 
 .caja-desktop.caja-canvas-item {
   color: #eeeeee;
-  text-shadow: 1px 1px transparent(black, 0.2); }
+  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.95), 0px 0px 2px rgba(0, 0, 0, 0.8); }
   .caja-desktop.caja-canvas-item:selected {
     background-color: rgba(255, 255, 255, 0.8);
     color: #ffffff;
-    box-shadow: none; }
+    box-shadow: none;
+    text-shadow: none; }
 
 .caja-side-pane notebook treeview.view,
 .caja-side-pane notebook textview.view text,
@@ -3660,11 +3661,12 @@ popover.emoji-completion .emoji:hover {
 
 .nemo-desktop .nemo-canvas-item {
   color: #eeeeee;
-  text-shadow: 1px 1px transparent(black, 0.2); }
+  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.95), 0px 0px 2px rgba(0, 0, 0, 0.8); }
   .nemo-desktop .nemo-canvas-item:selected {
     background-color: rgba(255, 255, 255, 0.8);
     color: #ffffff;
-    box-shadow: none; }
+    box-shadow: none;
+    text-shadow: none; }
 
 /**********
  * Panels *

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/sass/_applications.scss
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/sass/_applications.scss
@@ -10,12 +10,14 @@ $dark_sidebar_fg: #dadada;
 .caja-desktop {
   &.caja-canvas-item {
     color: #eeeeee;
-    text-shadow: 1px 1px transparent(black, 0.2);
+    text-shadow: 1px 1px 0px transparentize(black, 0.05),
+                 0px 0px 2px transparentize(black, 0.20);
 
     &:selected {
       background-color: transparentize($selected_fg_color, 0.2);
       color: $selected_fg_color;
       box-shadow: none;
+      text-shadow: none;
     }
   }
 }
@@ -145,12 +147,14 @@ $dark_sidebar_fg: #dadada;
 .nemo-desktop {
   .nemo-canvas-item {
     color: #eeeeee;
-    text-shadow: 1px 1px transparent(black, 0.2);
+    text-shadow: 1px 1px 0px transparentize(black, 0.05),
+                 0px 0px 2px transparentize(black, 0.20);
 
     &:selected {
       background-color: transparentize($selected_fg_color, 0.2);
       color: $selected_fg_color;
       box-shadow: none;
+      text-shadow: none;
     }
   }
 }

--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -3085,13 +3085,17 @@ vte-terminal {
 .nemo-desktop.nemo-canvas-item,
 .nautilus-desktop.nautilus-canvas-item {
   color: #ffffff;
-  text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
+  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.95), 0px 0px 2px rgba(0, 0, 0, 0.8); }
+  .nemo-desktop.nemo-canvas-item:hover,
+  .nautilus-desktop.nautilus-canvas-item:hover {
+    text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.85); }
   .nemo-desktop.nemo-canvas-item:active,
   .nautilus-desktop.nautilus-canvas-item:active {
     color: rgba(255, 255, 255, 0.87); }
   .nemo-desktop.nemo-canvas-item:selected,
   .nautilus-desktop.nautilus-canvas-item:selected {
-    color: #ffffff; }
+    color: #ffffff;
+    text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.85); }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
 .nautilus-list-dim-label {

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -3090,13 +3090,17 @@ vte-terminal {
 .nemo-desktop.nemo-canvas-item,
 .nautilus-desktop.nautilus-canvas-item {
   color: #ffffff;
-  text-shadow: 1px 1px rgba(0, 0, 0, 0.6); }
+  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.95), 0px 0px 2px rgba(0, 0, 0, 0.8); }
+  .nemo-desktop.nemo-canvas-item:hover,
+  .nautilus-desktop.nautilus-canvas-item:hover {
+    text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.85); }
   .nemo-desktop.nemo-canvas-item:active,
   .nautilus-desktop.nautilus-canvas-item:active {
     color: rgba(0, 0, 0, 0.87); }
   .nemo-desktop.nemo-canvas-item:selected,
   .nautilus-desktop.nautilus-canvas-item:selected {
-    color: #ffffff; }
+    color: #ffffff;
+    text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.85); }
 
 .nautilus-canvas-item.dim-label, label.nautilus-canvas-item.separator,
 .nautilus-list-dim-label {

--- a/src/Mint-Y/gtk-3.0/sass/_applications.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_applications.scss
@@ -129,10 +129,14 @@ vte-terminal {
 %nautilus_canvas_item,
 .nautilus-desktop.nautilus-canvas-item {
   color: $selected_fg_color;
-  text-shadow: 1px 1px transparentize(black, 0.4);
-
+  text-shadow: 1px 1px 0px transparentize(black, 0.05),
+               0px 0px 2px transparentize(black, 0.20);
+  &:hover { text-shadow: 1px 1px 0px transparentize(black, 0.15); }
   &:active { color: $fg_color; }
-  &:selected { color: $selected_fg_color; }
+  &:selected {
+    color: $selected_fg_color;
+    text-shadow: 1px 1px 0px transparentize(black, 0.15);
+  }
 }
 
 .nautilus-canvas-item.dim-label,


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![01_prev](https://github.com/linuxmint/mint-themes/assets/63073056/a3a4fc9d-49c3-415c-831c-c05444190ced) | ![01_after](https://github.com/linuxmint/mint-themes/assets/63073056/41626193-c5bc-4d06-b644-7f95883c196f) |
| ![02_prev](https://github.com/linuxmint/mint-themes/assets/63073056/6bdf38c4-18e6-4721-b625-44e6669ed64b) | ![02_after](https://github.com/linuxmint/mint-themes/assets/63073056/1c1d04f0-42a8-4cfb-aec2-06c8e009e273) |
| ![03_prev](https://github.com/linuxmint/mint-themes/assets/63073056/4605bb12-f6ec-48c0-9800-a4e881955025) | ![03_after](https://github.com/linuxmint/mint-themes/assets/63073056/71550925-dbdd-4af7-8618-e762935d05c8)  |

It improves the readability of the text of the items a bit when using brighter wallpaper images.

Adapted from @moloch1994's suggestion on https://github.com/orgs/linuxmint/discussions/296

#### TODO
- [x] Stress test using multiple stacked text-shadow effects vs CPU temperature and usage, ref. [comment below by @mtwebster](https://github.com/linuxmint/mint-themes/pull/466#issuecomment-1941975437)