### PR TITLE
Linux Mint theme fix expo-workspaces-name-entry

### DIFF
--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -2091,10 +2091,8 @@ StScrollBar StButton#vhandle:hover {
     selected-color: black;
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
-    width: 250px;
     height: 1.5em;
     box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.6);
-    text-align: center;
 }
 
 .expo-workspaces-name-entry#selected {

--- a/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/files/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -2091,6 +2091,7 @@ StScrollBar StButton#vhandle:hover {
     selected-color: black;
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
+    min-width: 80px;
     height: 1.5em;
     box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.6);
 }


### PR DESCRIPTION
Remove fixed width of label since "text-align: center;" doesn't do anything and text is left aligned.

cf. https://github.com/linuxmint/cinnamon/pull/12171