### PR TITLE
Define accent-color

### DIFF
--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-dark.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk-dark.css
@@ -3895,6 +3895,9 @@ window.background .lightdm-combo .cell, window.background .lightdm-combo button 
    ----------------
    use responsibly! */
 /*
+accent color, used by XDG-DESKTOP-PORTAL-XAPP */
+@define-color accent_color #9ab87c;
+/*
 widget text/foreground color */
 @define-color theme_fg_color #eeeeee;
 /*

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/gtk.css
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/gtk.css
@@ -3909,6 +3909,9 @@ window.background .lightdm-combo .cell, window.background .lightdm-combo button 
    ----------------
    use responsibly! */
 /*
+accent color, used by XDG-DESKTOP-PORTAL-XAPP */
+@define-color accent_color #9ab87c;
+/*
 widget text/foreground color */
 @define-color theme_fg_color #212121;
 /*

--- a/src/Mint-X/theme/Mint-X/gtk-3.0/sass/_colors-public.scss
+++ b/src/Mint-X/theme/Mint-X/gtk-3.0/sass/_colors-public.scss
@@ -5,6 +5,11 @@
 
 // Sass thinks we're using the colors in the variables as strings and may shoot
 // warning, it's innocuous and can be defeated by using "" + $var
+
+/*
+accent color, used by XDG-DESKTOP-PORTAL-XAPP */
+@define-color accent_color #{"" + $accent_color};
+
 /*
 widget text/foreground color */
 @define-color theme_fg_color #{"" +$fg_color};

--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -3987,6 +3987,7 @@ window.background.lightdm .lightdm-combo {
   border-radius: 0;
   background-color: transparent; }
 
+@define-color accent_color #35A854;
 @define-color theme_fg_color rgba(255, 255, 255, 0.87);
 @define-color theme_text_color #DADADA;
 @define-color theme_bg_color #2e2e33;

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -4004,6 +4004,7 @@ window.background.lightdm .lightdm-combo {
   background-color: #3f3f3f;
   color: #eeeeee; }
 
+@define-color accent_color #35A854;
 @define-color theme_fg_color rgba(0, 0, 0, 0.87);
 @define-color theme_text_color #303030;
 @define-color theme_bg_color #f8f8f9;

--- a/src/Mint-Y/gtk-3.0/sass/_colors-public.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_colors-public.scss
@@ -2,6 +2,7 @@
 
 // Sass thinks we're using the colors in the variables as strings and may shoot
 // warning, it's innocuous and can be defeated by using "" + $var
+@define-color accent_color #{"" + $accent_color};
 @define-color theme_fg_color #{"" + $fg_color};
 @define-color theme_text_color #{"" + $text_color};
 @define-color theme_bg_color #{"" + $bg_color};

--- a/src/Mint-Y/gtk-3.0/sass/_colors.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_colors.scss
@@ -116,7 +116,8 @@ $button_active_border: darken($button_border, 10%);
 $header_border_unfocused: lighten($header_border, 5%);
 
 // Accents
-$selected_bg_color: #35A854;
+$accent_color: #35A854;
+$selected_bg_color: $accent_color;
 $selected_fg_color: #FFFFFF;
 $selected_borders_color: darken($selected_bg_color, 15%);
 $wm_button_close_bg: $selected_bg_color;

--- a/src/Mint-Y/gtk-4.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-4.0/gtk-dark.css
@@ -3155,6 +3155,7 @@ menubutton arrow {
   menubutton arrow.right {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
 
+@define-color accent_color #35A854;
 @define-color theme_fg_color rgba(255, 255, 255, 0.87);
 @define-color theme_text_color #DADADA;
 @define-color theme_bg_color #2e2e33;

--- a/src/Mint-Y/gtk-4.0/gtk.css
+++ b/src/Mint-Y/gtk-4.0/gtk.css
@@ -3158,6 +3158,7 @@ menubutton arrow {
   menubutton arrow.right {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic"); }
 
+@define-color accent_color #35A854;
 @define-color theme_fg_color rgba(0, 0, 0, 0.87);
 @define-color theme_text_color #303030;
 @define-color theme_bg_color #f8f8f9;

--- a/src/Mint-Y/gtk-4.0/sass/_colors-public.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_colors-public.scss
@@ -2,6 +2,7 @@
 
 // Sass thinks we're using the colors in the variables as strings and may shoot
 // warning, it's innocuous and can be defeated by using "" + $var
+@define-color accent_color #{"" + $accent_color};
 @define-color theme_fg_color #{"" + $fg_color};
 @define-color theme_text_color #{"" + $text_color};
 @define-color theme_bg_color #{"" + $bg_color};

--- a/src/Mint-Y/gtk-4.0/sass/_colors.scss
+++ b/src/Mint-Y/gtk-4.0/sass/_colors.scss
@@ -116,7 +116,8 @@ $button_active_border: darken($button_border, 10%);
 $header_border_unfocused: lighten($header_border, 5%);
 
 // Accents
-$selected_bg_color: #35A854;
+$accent_color: #35A854;
+$selected_bg_color: $accent_color;
 $selected_fg_color: #FFFFFF;
 $selected_borders_color: darken($selected_bg_color, 15%);
 $wm_button_close_bg: $selected_bg_color;


### PR DESCRIPTION
This is used by XDG-DESKTOP-PORTAL-XAPP to provide the accent color via the accent color API.

It results in coloring libAdwaita apps with the selected GTK3 theme's accent color*

* Well, kinda, because libAdwaita stays in its own palette and choose its own version of red, or blue, or whatever is closest to our theme's accent.

ref: https://github.com/linuxmint/xdg-desktop-portal-xapp/pull/23