### PR TITLE
Mint-X cinnamon: GWL use fixed font size for window count badge

### DIFF
--- a/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
+++ b/src/Mint-X/theme/Mint-X/cinnamon/cinnamon.css
@@ -2139,6 +2139,7 @@ On-Screen Keyboard (>= Cinnamon 6.6)
     padding-left: 4px;
 }
 .grouped-window-list-number-label {
+    font-size: 11px;
     z-index: 99;
     color: rgb(70, 70, 70);
 }


### PR DESCRIPTION
So that it isn't too big with user font scaling