### PR TITLE
Mint-Y cinnamon: window-list applet set notification badge font size

### DIFF
--- a/src/Mint-Y/cinnamon/cinnamon-dark.css
+++ b/src/Mint-Y/cinnamon/cinnamon-dark.css
@@ -1240,6 +1240,9 @@ StScrollBar {
   background-color: #35a854;
   margin: 0; }
 
+.grouped-window-list-notifications-badge-label {
+  font-size: 12px; }
+
 .grouped-window-list-button-label {
   padding-left: 4px; }
 

--- a/src/Mint-Y/cinnamon/cinnamon.css
+++ b/src/Mint-Y/cinnamon/cinnamon.css
@@ -1240,6 +1240,9 @@ StScrollBar {
   background-color: #35a854;
   margin: 0; }
 
+.grouped-window-list-notifications-badge-label {
+  font-size: 12px; }
+
 .grouped-window-list-button-label {
   padding-left: 4px; }
 

--- a/src/Mint-Y/cinnamon/sass/_common.scss
+++ b/src/Mint-Y/cinnamon/sass/_common.scss
@@ -1650,6 +1650,10 @@ $base_padding: 7px;
     margin: 0;
   }
 
+  &-notifications-badge-label {
+    font-size: 12px;
+  }
+
   &-button-label {
     padding-left: 4px;
   }


### PR DESCRIPTION
This is needed to set a fixed notification badge font size in the window-list applet as the selector `window-list-item-box.bottom StLabel{}` (in Mint-Y), having a higher specificity, overrides the `grouped-window-list-notification-badge-label{}` selector in the default cinnamon theme.

Fixes notification badges being too big in window-list applet with user font scaling.