### PR TITLE
fixed scrollbar overwriting window borders on wayland

### DIFF
--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -1751,6 +1751,7 @@ notebook {
       padding: 2px; }
 
 scrollbar {
+  border: 1px solid transparent;
   background-color: #2c2c30;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
@@ -2516,6 +2517,12 @@ filechooser actionbar {
 filechooserbutton:drop(active) {
   box-shadow: none;
   border-color: transparent; }
+
+printdialog paper {
+  background-color: white;
+  color: rgba(255, 255, 255, 0.87);
+  border: 1px solid #202023;
+  padding: 0; }
 
 .sidebar {
   border-style: none;

--- a/src/Mint-Y/gtk-3.0/gtk-dark.css
+++ b/src/Mint-Y/gtk-3.0/gtk-dark.css
@@ -1751,12 +1751,13 @@ notebook {
       padding: 2px; }
 
 scrollbar {
-  border: 1px solid transparent;
   background-color: #2c2c30;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
     -GtkScrollbar-has-backward-stepper: false;
     -GtkScrollbar-has-forward-stepper: false; }
+  terminal-screen-container scrollbar {
+    border: 1px solid transparent; }
   scrollbar.top {
     border-bottom: 1px solid #202023; }
   scrollbar.bottom {

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -1756,6 +1756,7 @@ notebook {
       padding: 2px; }
 
 scrollbar {
+  border: 1px solid transparent;
   background-color: #fcfcfc;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
@@ -2521,6 +2522,12 @@ filechooser actionbar {
 filechooserbutton:drop(active) {
   box-shadow: none;
   border-color: transparent; }
+
+printdialog paper {
+  background-color: white;
+  color: rgba(0, 0, 0, 0.87);
+  border: 1px solid #c8c8ce;
+  padding: 0; }
 
 .sidebar {
   border-style: none;

--- a/src/Mint-Y/gtk-3.0/gtk.css
+++ b/src/Mint-Y/gtk-3.0/gtk.css
@@ -1756,12 +1756,13 @@ notebook {
       padding: 2px; }
 
 scrollbar {
-  border: 1px solid transparent;
   background-color: #fcfcfc;
   transition: 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94); }
   * {
     -GtkScrollbar-has-backward-stepper: false;
     -GtkScrollbar-has-forward-stepper: false; }
+  terminal-screen-container scrollbar {
+    border: 1px solid transparent; }
   scrollbar.top {
     border-bottom: 1px solid #c8c8ce; }
   scrollbar.bottom {

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -1891,6 +1891,7 @@ scrollbar {
 
   $_slider_min_length: 40px;
 
+  border: 1px solid transparent;
   background-color: $_scrollbar_bg_color;
   transition: 300ms $ease-out-quad;
 

--- a/src/Mint-Y/gtk-3.0/sass/_common.scss
+++ b/src/Mint-Y/gtk-3.0/sass/_common.scss
@@ -1891,7 +1891,7 @@ scrollbar {
 
   $_slider_min_length: 40px;
 
-  border: 1px solid transparent;
+  terminal-screen-container & { border: 1px solid transparent; }
   background-color: $_scrollbar_bg_color;
   transition: 300ms $ease-out-quad;
 


### PR DESCRIPTION
the scrollbar overwrites the window border on wayland
creating a 1px transparent border around the scrollbar fixes it
<img width="40%" height="40%" alt="Screenshot from 2026-02-27 23-02-36" src="https://github.com/user-attachments/assets/e26b0393-acf4-4f7a-91dc-50dd67d52a79" /> <img width="40%" height="40%" alt="Screenshot from 2026-02-27 23-06-58" src="https://github.com/user-attachments/assets/bb9ecb67-2f41-486b-ac8e-d21eadd1144b" />

mint-l has the same issue, i also made a pr there with the same change

i opened a wayland issue on this a while ago, fixed it for my theme and closed the issue but forgot to fix it for mint-y and mint-l https://github.com/linuxmint/wayland/issues/156